### PR TITLE
MCP session hardening: retry-safety + project binding

### DIFF
--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -117,10 +117,18 @@ function withoutImageData(payload: SnapshotPayload): Record<string, unknown> {
 export class EngineApiClient {
   private port: number;
   private token: string;
+  // The project this session is BOUND to — the projectIdHash reported by the
+  // engine when this client first connected. Sent on every mutating op so the
+  // engine's identity guard (local_api_server.cpp ~271-302) atomically rejects a
+  // write aimed at a DIFFERENT project (e.g. after the user switched projects
+  // in-place). Health is the only identity signal the MCP has — /api/state/project
+  // carries no path and /api/health exposes only projectIdHash, not the raw id.
+  private boundProjectIdHash?: string;
 
-  constructor(port: number, token: string) {
+  constructor(port: number, token: string, boundProjectIdHash?: string) {
     this.port = port;
     this.token = token;
+    this.boundProjectIdHash = boundProjectIdHash;
   }
 
   static async connect(): Promise<EngineApiClient> {
@@ -140,7 +148,39 @@ export class EngineApiClient {
       );
     }
 
-    return new EngineApiClient(port, token);
+    // Bind to whatever project is open right now. On a genuine engine restart the
+    // token rotates and getClient() rebuilds this client, so a restart naturally
+    // rebinds to the current project. An in-place project switch keeps the same
+    // token, so the cached client retains its original binding and the engine
+    // rejects mismatched mutations until the agent explicitly rebinds.
+    return new EngineApiClient(port, token, health.projectIdHash);
+  }
+
+  /** The projectIdHash this session is bound to (undefined if none was reported
+   *  at connect — e.g. no project open yet). */
+  getBoundProjectIdHash(): string | undefined {
+    return this.boundProjectIdHash;
+  }
+
+  /**
+   * Re-read health and rebind to the currently-open project. Called by
+   * summer_get_project_context so the agent can INTENTIONALLY follow a project
+   * switch (the deliberate escape hatch after an identity_mismatch). Returns the
+   * new bound hash. Reads carry no identity, so this always reaches the engine
+   * even when a mutation would be rejected.
+   */
+  async rebind(): Promise<string | undefined> {
+    const health = await checkEngineHealth(this.port);
+    if (health) {
+      this.boundProjectIdHash = health.projectIdHash;
+    }
+    return this.boundProjectIdHash;
+  }
+
+  /** Identity to attach to a MUTATING command's options so the engine can reject
+   *  a wrong-project write. Empty when unbound (engine then skips the check). */
+  private identityOptions(): Record<string, unknown> {
+    return this.boundProjectIdHash ? { projectIdHash: this.boundProjectIdHash } : {};
   }
 
   private async request(
@@ -244,7 +284,11 @@ export class EngineApiClient {
     // Ops may include long-running work (ImportFromUrlBatch, GitCommit); the
     // engine keeps it "running" and we poll. 120s budget. Resolves legacy-200 or
     // async-202 (Block E).
-    return this._requestQueued("POST", "/api/ops", { ops, options }, 120_000);
+    // Attach the bound project identity so the engine rejects a write aimed at a
+    // different project (identity_mismatch, atomic — before any op applies).
+    const merged = { ...this.identityOptions(), ...(options ?? {}) };
+    const body = Object.keys(merged).length ? { ops, options: merged } : { ops };
+    return this._requestQueued("POST", "/api/ops", body, 120_000);
   }
 
   async getSceneState(): Promise<unknown> {
@@ -275,12 +319,25 @@ export class EngineApiClient {
     // Cold-load on large projects can take 25-40s. 60s budget.
     // The engine reads play params from body.options (tool_net_thread.cpp:503),
     // and the play handler reads options["scene"] — a top-level { scene } is
-    // dropped, so the scene MUST be nested inside options.
-    return this._requestQueued("POST", "/api/play", scene ? { options: { scene } } : {}, 60_000);
+    // dropped, so the scene MUST be nested inside options. The bound identity
+    // rides in the same options dict so play is refused on a mismatched project.
+    const options = { ...this.identityOptions(), ...(scene ? { scene } : {}) };
+    return this._requestQueued(
+      "POST",
+      "/api/play",
+      Object.keys(options).length ? { options } : {},
+      60_000
+    );
   }
 
   async stop(): Promise<unknown> {
-    return this._requestQueued("POST", "/api/stop", undefined, 15_000);
+    const options = this.identityOptions();
+    return this._requestQueued(
+      "POST",
+      "/api/stop",
+      Object.keys(options).length ? { options } : undefined,
+      15_000
+    );
   }
 
   async readFile(

--- a/src/mcp/binding.integration.test.ts
+++ b/src/mcp/binding.integration.test.ts
@@ -1,0 +1,183 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+/**
+ * Project-binding proof over REAL HTTP.
+ *
+ * A fake engine emulates the identity preflight (local_api_server.cpp ~271-302):
+ * a command carrying options.projectIdHash that differs from the engine's current
+ * project is rejected with terminalState "identity_mismatch" BEFORE anything is
+ * applied; an empty/absent hash skips the check. Reads (GET /api/state/*) carry
+ * no identity and always succeed.
+ *
+ * Proves: the MCP client binds to the open project on connect, sends that hash on
+ * mutations (so a write aimed at a switched-to project is atomically rejected),
+ * never sends it on reads (so the rebind path stays open), and rebinds on demand.
+ *
+ * Only the credential-file readers are stubbed, so nothing touches ~/.summer.
+ */
+
+const engine = {
+  token: "tok",
+  port: 0,
+  projectIdHash: "hash-A",
+  lastOpsBody: null as unknown,
+  lastReadHadIdentity: false,
+};
+
+vi.mock("../lib/engine.js", async (importActual) => {
+  const actual = await importActual<typeof import("../lib/engine.js")>();
+  return {
+    ...actual,
+    getApiPort: vi.fn(async () => engine.port),
+    getApiToken: vi.fn(async () => engine.token),
+  };
+});
+
+import { getClient, resetClient } from "./server.js";
+import { withEngine } from "./tools/with-engine.js";
+
+let server: Server;
+
+function readJson(req: import("node:http").IncomingMessage): Promise<Record<string, unknown>> {
+  return new Promise((resolve) => {
+    let raw = "";
+    req.on("data", (c) => (raw += c));
+    req.on("end", () => {
+      try {
+        resolve(raw ? JSON.parse(raw) : {});
+      } catch {
+        resolve({});
+      }
+    });
+  });
+}
+
+beforeAll(async () => {
+  server = createServer(async (req, res) => {
+    const send = (code: number, body: unknown) => {
+      res.writeHead(code, { "content-type": "application/json" });
+      res.end(JSON.stringify(body));
+    };
+    const url = req.url ?? "";
+
+    if (url.startsWith("/api/health")) {
+      send(200, {
+        ok: true,
+        engine: "summer",
+        version: "0.5.42",
+        port: engine.port,
+        instanceId: "inst",
+        projectIdHash: engine.projectIdHash,
+      });
+      return;
+    }
+
+    if (url.startsWith("/api/ops")) {
+      const body = await readJson(req);
+      engine.lastOpsBody = body;
+      const opts = (body.options ?? {}) as Record<string, unknown>;
+      const want = typeof opts.projectIdHash === "string" ? opts.projectIdHash : "";
+      // Identity preflight — reject BEFORE apply when a non-empty hash mismatches.
+      if (want && want !== engine.projectIdHash) {
+        send(200, {
+          ok: false,
+          status: "error",
+          terminalState: "identity_mismatch",
+          errorClass: "rejected_identity",
+          error: "projectIdHash mismatch",
+        });
+        return;
+      }
+      send(200, { status: "ok", terminalState: "applied", results: [{ ok: true, op: "Probe" }] });
+      return;
+    }
+
+    if (url.startsWith("/api/state/")) {
+      // A read must NOT carry identity (GET has no body); record that we saw none.
+      engine.lastReadHadIdentity = false;
+      send(200, { ok: true, data: { entries: [] } });
+      return;
+    }
+
+    send(404, { ok: false, error: "not found" });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  engine.port = (server.address() as AddressInfo).port;
+});
+
+afterAll(() => server.close());
+afterEach(() => resetClient());
+
+describe("MCP project binding — engine-enforced, atomic", () => {
+  it("binds to the open project on connect and stamps its hash on mutations", async () => {
+    engine.projectIdHash = "hash-A";
+    const client = await getClient();
+    expect(client.getBoundProjectIdHash()).toBe("hash-A");
+
+    const res = (await client.executeOps([{ op: "Probe" }])) as Record<string, unknown>;
+    expect(res.terminalState).toBe("applied");
+    // The mutation body carried the bound identity.
+    const body = engine.lastOpsBody as { options?: { projectIdHash?: string } };
+    expect(body.options?.projectIdHash).toBe("hash-A");
+  });
+
+  it("is atomically REJECTED when the engine switched to a different project", async () => {
+    engine.projectIdHash = "hash-A";
+    const client = await getClient(); // bound to A
+    expect(client.getBoundProjectIdHash()).toBe("hash-A");
+
+    // User switches project in the engine: A -> B. Same token, so the cached
+    // client keeps its binding to A.
+    engine.projectIdHash = "hash-B";
+
+    const res = (await client.executeOps([{ op: "Probe" }])) as Record<string, unknown>;
+    expect(res.terminalState).toBe("identity_mismatch"); // never applied to B
+  });
+
+  it("keeps READS working after a switch (no identity on GET) so the session can recover", async () => {
+    engine.projectIdHash = "hash-A";
+    const client = await getClient();
+    engine.projectIdHash = "hash-B"; // switch
+
+    const scene = (await client.getSceneState()) as Record<string, unknown>;
+    expect(scene.ok).toBe(true); // read is not identity-gated
+
+    // Explicit rebind (what summer_get_project_context does) follows the switch.
+    const rebound = await client.rebind();
+    expect(rebound).toBe("hash-B");
+
+    // Now mutations target B and apply.
+    const res = (await client.executeOps([{ op: "Probe" }])) as Record<string, unknown>;
+    expect(res.terminalState).toBe("applied");
+    const body = engine.lastOpsBody as { options?: { projectIdHash?: string } };
+    expect(body.options?.projectIdHash).toBe("hash-B");
+  });
+
+  it("surfaces an actionable rebind hint to the agent via withEngine on a switch", async () => {
+    engine.projectIdHash = "hash-A";
+    await getClient(); // bind to A
+    engine.projectIdHash = "hash-B"; // switch
+
+    const res = await withEngine(async (client) => client.executeOps([{ op: "Probe" }]));
+    expect(res.isError).toBe(true);
+    const text = (res.content[0] as { text?: string }).text ?? "";
+    expect(text.toLowerCase()).toContain("different project");
+    expect(text).toContain("summer_get_project_context");
+  });
+
+  it("sends NO identity when unbound (no project hash) so the engine skips the check", async () => {
+    engine.projectIdHash = ""; // engine reports no project hash
+    const client = await getClient();
+    expect(client.getBoundProjectIdHash()).toBeFalsy();
+
+    const res = (await client.executeOps([{ op: "Probe" }])) as Record<string, unknown>;
+    expect(res.terminalState).toBe("applied");
+    const body = engine.lastOpsBody as { ops?: unknown; options?: unknown };
+    // Backward-compatible body shape: no options injected.
+    expect(body.options).toBeUndefined();
+  });
+});

--- a/src/mcp/tools/project-tools.test.ts
+++ b/src/mcp/tools/project-tools.test.ts
@@ -142,6 +142,7 @@ priority: locked
           scenePath: "res://main.tscn",
         },
       })),
+      rebind: vi.fn(async () => "test-project-hash"),
     } as never);
 
     const { server, tools } = createFakeServer();

--- a/src/mcp/tools/project-tools.ts
+++ b/src/mcp/tools/project-tools.ts
@@ -252,6 +252,12 @@ Use this first in every fresh chat to avoid guessing scene filenames or editing 
         const mainScene = getMainScene(projectState);
         const currentScene = getCurrentScene(projectState, sceneState, health);
 
+        // This tool is the deliberate (re)bind point: capture the currently-open
+        // project as the one this session's mutations are pinned to. After an
+        // engine project switch the agent calls this to intentionally follow the
+        // new project; subsequent edits then target it instead of being rejected.
+        const boundProjectIdHash = await client.rebind();
+
         return {
           health,
           project: projectState,
@@ -260,6 +266,7 @@ Use this first in every fresh chat to avoid guessing scene filenames or editing 
           projectPath,
           currentScene,
           mainScene,
+          boundProjectIdHash,
           projectMemory: getProjectMemorySummary(projectPath),
           guidance: mainScene
             ? "Use `summer_open_scene` with `mainScene` if no scene is open."

--- a/src/mcp/tools/with-engine.reconnect.test.ts
+++ b/src/mcp/tools/with-engine.reconnect.test.ts
@@ -1,14 +1,22 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 /**
- * Transient-disconnect recovery. The engine rotates its api-token on every launch
- * and can move ports, so a restart that lands DURING a tool call shows up as a
- * stale-token 401, an ECONNREFUSED on the old port, or a soft `not_connected` /
- * `identity_mismatch` terminal state. withEngine must drop the cached client and
- * retry ONCE so the drop heals itself instead of surfacing as "disconnected".
+ * Transient-disconnect recovery, NARROWED for mutation-safety.
  *
- * It must NOT retry ambiguous/intentional failures (timed_out / content_mismatch
- * / denied / canceled) — those could double-apply a mutation or mask user intent.
+ * The engine rotates its api-token on every launch and can move ports, so a
+ * restart that lands DURING a tool call shows up as a stale-token 401 or a
+ * connect failure. withEngine retries ONCE, but only where nothing could have
+ * been applied:
+ *   - a connect/preflight failure (getClient threw — request never submitted)
+ *   - a stale-token 401/403 (engine rejects at auth, before queue/apply)
+ *
+ * It must NOT retry:
+ *   - a generic connection error thrown from INSIDE the tool closure (could be a
+ *     disconnect mid-operation where a mutation already partially applied, and
+ *     the MCP sends no idempotency key the engine can dedup on)
+ *   - soft failure terminal states (not_connected / identity_mismatch): a retry
+ *     cannot fix a project switch — surface it
+ *   - ambiguous/intentional failures (timed_out / invalid op / 5xx)
  */
 
 const mockGetClient = vi.fn();
@@ -23,16 +31,16 @@ vi.mock("../../lib/telemetry.js", () => ({
   recordMcpSession: vi.fn(),
 }));
 
-import { withEngine } from "./with-engine.js";
+import { withEngine, isAuthError } from "./with-engine.js";
 
 afterEach(() => vi.clearAllMocks());
 
-function resultText(res: { content: { text: string }[]; isError?: boolean }): string {
+function resultText(res: { content: { text?: string }[]; isError?: boolean }): string {
   return res.content[0]?.text ?? "";
 }
 
-describe("withEngine — transparent reconnect on a transient drop", () => {
-  it("retries once after a stale-token 401 and returns the recovered result", async () => {
+describe("withEngine — safe retry only where nothing could have applied", () => {
+  it("retries once after a stale-token 401 (pre-apply auth reject) and recovers", async () => {
     mockGetClient.mockResolvedValue({});
     let calls = 0;
     const res = await withEngine(async () => {
@@ -46,41 +54,58 @@ describe("withEngine — transparent reconnect on a transient drop", () => {
     expect(resultText(res)).toContain("42");
   });
 
-  it("retries once after an ECONNREFUSED on the old port", async () => {
-    mockGetClient.mockResolvedValue({});
-    let calls = 0;
-    const res = await withEngine(async () => {
-      calls += 1;
-      if (calls === 1) throw new Error("fetch failed");
-      return { ok: true };
+  it("retries a connect/preflight failure (getClient threw — nothing submitted)", async () => {
+    let getCalls = 0;
+    mockGetClient.mockImplementation(async () => {
+      getCalls += 1;
+      if (getCalls === 1) throw new Error("Summer Engine is not running");
+      return {};
     });
-    expect(calls).toBe(2);
+    let fnCalls = 0;
+    const res = await withEngine(async () => {
+      fnCalls += 1;
+      return { ok: true, value: 7 };
+    });
+    expect(getCalls).toBe(2);
+    expect(fnCalls).toBe(1);
     expect(res.isError).toBeFalsy();
+    expect(resultText(res)).toContain("7");
   });
 
-  it("retries once on a soft not_connected terminalState (nothing applied) then succeeds", async () => {
+  it("does NOT retry a generic connection error thrown from inside fn (may be mid-mutation)", async () => {
     mockGetClient.mockResolvedValue({});
     let calls = 0;
     const res = await withEngine(async () => {
       calls += 1;
-      if (calls === 1) return { terminalState: "not_connected" };
-      return { status: "ok", terminalState: "applied", results: [{ ok: true, op: "AddNode" }] };
+      throw new Error("fetch failed"); // ECONNREFUSED after submission — unsafe to retry
     });
-    expect(calls).toBe(2);
-    expect(mockResetClient).toHaveBeenCalled();
-    expect(res.isError).toBeFalsy();
+    expect(calls).toBe(1); // no double-submit
+    expect(mockResetClient).toHaveBeenCalled(); // still drops the stale client
+    expect(res.isError).toBe(true);
+    expect(resultText(res)).toMatch(/fetch failed/i);
   });
 
-  it("retries once on identity_mismatch (wrong instance — never mutated) then succeeds", async () => {
+  it("surfaces a not_connected terminalState without retrying", async () => {
     mockGetClient.mockResolvedValue({});
     let calls = 0;
     const res = await withEngine(async () => {
       calls += 1;
-      if (calls === 1) return { terminalState: "identity_mismatch" };
-      return { status: "ok", terminalState: "applied", results: [{ ok: true }] };
+      return { terminalState: "not_connected" };
     });
-    expect(calls).toBe(2);
-    expect(res.isError).toBeFalsy();
+    expect(calls).toBe(1);
+    expect(res.isError).toBe(true);
+  });
+
+  it("surfaces identity_mismatch (project switch) without retrying — a retry can't fix it", async () => {
+    mockGetClient.mockResolvedValue({});
+    let calls = 0;
+    const res = await withEngine(async () => {
+      calls += 1;
+      return { terminalState: "identity_mismatch", error: "projectIdHash mismatch" };
+    });
+    expect(calls).toBe(1);
+    expect(res.isError).toBe(true);
+    expect(resultText(res)).toMatch(/mismatch/i);
   });
 
   it("does NOT retry an ambiguous timed_out (op may have landed) — surfaces it", async () => {
@@ -90,7 +115,7 @@ describe("withEngine — transparent reconnect on a transient drop", () => {
       calls += 1;
       return { terminalState: "timed_out" };
     });
-    expect(calls).toBe(1); // no double-submit
+    expect(calls).toBe(1);
     expect(res.isError).toBe(true);
     expect(resultText(res)).toMatch(/tim/i);
   });
@@ -107,7 +132,7 @@ describe("withEngine — transparent reconnect on a transient drop", () => {
     expect(resultText(res)).toContain("invalid value");
   });
 
-  it("surfaces the disconnect after the retry also fails (engine truly down)", async () => {
+  it("surfaces the disconnect after a 401 that persists across the retry", async () => {
     mockGetClient.mockResolvedValue({});
     let calls = 0;
     const res = await withEngine(async () => {
@@ -119,15 +144,30 @@ describe("withEngine — transparent reconnect on a transient drop", () => {
     expect(resultText(res)).toMatch(/401/);
   });
 
-  it("still resets the client on a non-retriable throw (preserves prior behavior)", async () => {
+  it("does NOT retry a 500 (may have mutated) — surfaces and resets", async () => {
     mockGetClient.mockResolvedValue({});
     let calls = 0;
     const res = await withEngine(async () => {
       calls += 1;
       throw new Error("Engine API error 500: internal");
     });
-    expect(calls).toBe(1); // a 500 may have mutated — do not retry
+    expect(calls).toBe(1);
     expect(mockResetClient).toHaveBeenCalled();
     expect(res.isError).toBe(true);
+  });
+});
+
+describe("isAuthError", () => {
+  it("matches 401/403/unauthorized only", () => {
+    expect(isAuthError(new Error("Engine API error 401: x"))).toBe(true);
+    expect(isAuthError(new Error("Engine API error 403"))).toBe(true);
+    expect(isAuthError(new Error("Unauthorized"))).toBe(true);
+  });
+
+  it("does NOT match connection/timeout errors (unsafe to retry from inside fn)", () => {
+    expect(isAuthError(new Error("fetch failed"))).toBe(false);
+    expect(isAuthError(new Error("ECONNREFUSED"))).toBe(false);
+    expect(isAuthError(new Error("The operation timed out"))).toBe(false);
+    expect(isAuthError(new Error("Engine API error 500"))).toBe(false);
   });
 });

--- a/src/mcp/tools/with-engine.ts
+++ b/src/mcp/tools/with-engine.ts
@@ -83,45 +83,26 @@ export function extractOpError(result: unknown): string | null {
   return null;
 }
 
-// Terminal states where the engine GUARANTEES the op never landed, so dropping
-// the cached client and retrying once is safe (no double-mutation). Everything
-// else — timed_out (may still be running), content_mismatch / denied / canceled
-// (intentional) — must surface, never silently retry.
-const RECONNECTABLE_TERMINAL_STATES: ReadonlySet<string> = new Set([
-  "not_connected",
-  "identity_mismatch",
-]);
-
-function terminalStateOf(result: unknown): string | null {
-  if (!result || typeof result !== "object") return null;
-  const ts = (result as OpResult).terminalState;
-  return typeof ts === "string" && ts.length > 0 ? ts : null;
-}
-
 /**
- * A thrown transport error is safe to retry only when the engine provably never
- * applied the op: a stale-token rejection (401/403, after the engine rotated its
- * api-token on relaunch) or an unreachable/closed port (connection refused/reset,
- * after the engine moved ports or is mid-restart). A timeout or any 5xx may have
- * mutated, so those surface instead of risking a double-apply on retry.
+ * An auth failure is the ONE class of thrown error that is provably pre-apply:
+ * the engine rejects on the Bearer-token check (tool_net_thread.cpp::_validate_auth)
+ * BEFORE the op is queued or applied, so reconnecting with the fresh api-token and
+ * retrying cannot double-apply a mutation. This is exactly the stale-token case
+ * after the engine rotates its api-token on relaunch.
+ *
+ * Deliberately NARROW. A generic connection error (ECONNREFUSED / "fetch failed")
+ * thrown from inside the tool closure is NOT retriable here, because it may be a
+ * disconnect mid-operation where a mutation already partially applied — and the
+ * MCP sends no idempotency key the engine can dedup on, so a blind retry would
+ * re-apply it. The restart-between-calls case is handled proactively by
+ * getClient()'s credential-drift check; the connect/preflight-failure case is
+ * retried separately in withEngine (nothing is submitted there).
  *
  * Exported for unit tests.
  */
-export function isReconnectableThrow(err: unknown): boolean {
+export function isAuthError(err: unknown): boolean {
   const m = (err instanceof Error ? err.message : String(err)).toLowerCase();
-  if (m.includes("timed out") || m.includes("timeout") || m.includes("aborted")) {
-    return false;
-  }
-  return (
-    m.includes("401") ||
-    m.includes("403") ||
-    m.includes("unauthorized") ||
-    m.includes("econnrefused") ||
-    m.includes("econnreset") ||
-    m.includes("fetch failed") ||
-    m.includes("not running") ||
-    m.includes("not responding")
-  );
+  return m.includes("401") || m.includes("403") || m.includes("unauthorized");
 }
 
 function buildActionHint(message: string): string | null {
@@ -150,28 +131,36 @@ export async function withEngine<T>(
   // No await, no throw, no quota gating.
   recordMcpSession();
 
-  // The engine rotates its api-token and can move ports on every launch, so a
-  // restart that lands DURING a tool call shows up as a stale-token 401, an
-  // ECONNREFUSED on the old port, or a soft not_connected / identity_mismatch
-  // terminal state. Drop the cached client and retry ONCE so a transient drop
-  // heals itself (getClient reconnects with the fresh creds) instead of
-  // surfacing as a "disconnected" error. Only provably-not-applied failures are
-  // retried — see RECONNECTABLE_TERMINAL_STATES / isReconnectableThrow.
+  // The engine rotates its api-token (and can move ports) on every launch. The
+  // proactive credential-drift check in getClient() reconnects when a restart
+  // happened BETWEEN calls; this loop only covers the race where the restart
+  // lands DURING a call. We retry ONLY where nothing could have been applied:
+  //   - a connect/preflight failure (getClient threw — request never submitted)
+  //   - a stale-token 401/403 (engine rejects at auth, before queue/apply)
+  // A generic connection error thrown from inside fn() is NOT retried: it may be
+  // a disconnect mid-operation where a mutation already partially applied, and
+  // the MCP sends no idempotency key the engine can dedup on. A soft failure
+  // terminal state (e.g. identity_mismatch from a project switch) is surfaced,
+  // never silently retried — a retry cannot fix a project switch.
   const MAX_ATTEMPTS = 2;
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    let client: Awaited<ReturnType<typeof getClient>>;
     try {
-      const client = await getClient();
+      client = await getClient();
+    } catch (err) {
+      // Pre-submission: the request never went out, so reconnect and retry.
+      resetClient();
+      lastError = err;
+      if (attempt < MAX_ATTEMPTS) continue;
+      break;
+    }
+
+    try {
       const result = await fn(client);
       const opError = extractOpError(result);
       if (opError) {
-        const ts = terminalStateOf(result);
-        if (ts && RECONNECTABLE_TERMINAL_STATES.has(ts) && attempt < MAX_ATTEMPTS) {
-          resetClient();
-          lastError = new Error(opError);
-          continue;
-        }
         const hint = buildActionHint(opError);
         const message = hint ? `${opError}\n\nHint: ${hint}` : opError;
         return { content: [{ type: "text", text: message }], isError: true };
@@ -181,14 +170,11 @@ export async function withEngine<T>(
       }
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     } catch (err) {
-      // A thrown error means the cached client may be pointed at a dead/rotated
-      // engine — always drop it (prior behavior). Retry once only for
-      // connection-class throws that provably did not mutate.
+      // Drop the cached client (it may point at a dead/rotated engine). Retry
+      // once only for a provably pre-apply auth failure; anything else surfaces.
       resetClient();
       lastError = err;
-      if (attempt < MAX_ATTEMPTS && isReconnectableThrow(err)) {
-        continue;
-      }
+      if (attempt < MAX_ATTEMPTS && isAuthError(err)) continue;
       break;
     }
   }

--- a/src/mcp/tools/with-engine.ts
+++ b/src/mcp/tools/with-engine.ts
@@ -108,6 +108,15 @@ export function isAuthError(err: unknown): boolean {
 function buildActionHint(message: string): string | null {
   const normalized = message.toLowerCase();
 
+  if (
+    normalized.includes("identity_mismatch") ||
+    normalized.includes("projectidhash mismatch") ||
+    normalized.includes("projectid mismatch") ||
+    normalized.includes("wrong project/instance")
+  ) {
+    return "Summer Engine is now on a DIFFERENT project than this session is bound to — nothing was applied (your edit did NOT land in the wrong project). If you meant to work on the now-open project, call `summer_get_project_context` to rebind to it, then retry. If not, switch the engine back to the original project first.";
+  }
+
   if (normalized.includes("no scene open") || normalized.includes("no edited scene")) {
     return "No scene is currently open. Call `summer_get_project_context` first, then `summer_open_main_scene` (or `summer_open_scene` with a known .tscn path).";
   }


### PR DESCRIPTION
Two follow-ups to the session-reconnect fix shipped in **2.6.3** (`6f0964b`). Completes the original mandate: *bind and retain the project, and reconnect cleanly after a transient drop.*

## 1. Retry-safety (`dd91f2e`) — correctness fix to shipped code
The 2.6.3 retry re-ran **any** connection-class throw, including `ECONNREFUSED`/`fetch failed` raised from **inside** a tool call. If that lands during the ops result-poll (after submission), some ops may have applied, and the MCP sends no idempotency key the engine can dedup on → **double-applied mutation**. Narrowed the retry to provably pre-apply cases only: connect/preflight failure + stale-token 401/403 (`isAuthError`). Dropped the dead/wrong soft-terminal-state retry (`not_connected` is never emitted by the engine; `identity_mismatch` = a project switch, which a retry can't fix — it's surfaced).

## 2. Project binding (`beb19dc`) — the second half of "disconnects from the project"
The MCP tracked **no** project — it followed whatever engine owned the port. After an in-place project switch, the agent's edits landed **silently in the wrong project** because the MCP never opted into the engine's identity guard (`local_api_server.cpp ~271-302`), which needs `options.projectIdHash` and is skipped when empty.

- `EngineApiClient` binds to the open project's `projectIdHash` at connect (the only identity signal the MCP has — `/api/state/project` carries no path; `/api/health` exposes only the hash).
- The bound hash is stamped on every **mutation** (`executeOps`/`play`/`stop`) → the engine **atomically rejects** a write aimed at a different project (`identity_mismatch`, before any op applies). **Not** sent on reads (reads are identity-gated too, so keeping them identity-free preserves the post-switch recovery path).
- `withEngine` surfaces an actionable **rebind hint** on `identity_mismatch` (no silent retry).
- `summer_get_project_context` is the explicit **rebind** point (re-reads health, rebinds, returns `boundProjectIdHash`).

Strictly additive: no false rejects (matching/empty hash passes), a no-op on pre-R1 engines, full protection once the engine re-mints identity on switch (R1 `b4c54baba9`, built).

## Verified LIVE (not just unit tests)
Against a **real running engine** (0.5.42, `:6550`): a client bound to the wrong hash → `terminalState=identity_mismatch` / `errorClass=rejected_identity` ("projectIdHash mismatch"), **nothing applied**; correct/empty hash passes the gate. The **real MCP stdio server** bound `summer_get_project_context` to the live project hash. Plus a real-HTTP integration test of the full stack (bind → reject-on-switch → rebind-hint → rebind-recovers → backward-compat). Full suite **322 green**; `tsc` clean.

Ships as the next npm (2.6.4). MCP/CLI repo only — no web/engine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)