### PR TITLE
fix: bind project identity and prepare CLI 2.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to summer-engine will be documented here. Following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/).
 
+## [2.6.6] — 2026-07-15 — "Project-bound engine requests"
+
+### Fixed
+- Every local engine request now carries the engine instance ID, stable project ID, project ID hash, and identity protocol version captured when the CLI connects. This lets compatible engine builds reject stale requests after a project or engine switch instead of acting on the wrong target.
+- An explicit project rebind now refreshes the complete engine and project identity, while keeping the existing project-hash mutation guard and screenshot drift checks.
+- Summer Cloud's engine bridge now binds its save, rescan, and scene reload requests to the project it verified on disk.
+
+### Changed
+- Summer Cloud is documented as an optional Research Preview instead of part of the core local CLI and MCP workflow.
+- Release metadata and the manual npm runbook now pin the public registry and require a clean, reviewed public source checkout.
+
 ## [2.6.5] — 2026-07-04 — "Cloud tools don't need the engine"
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,22 +23,6 @@ Three names, one npm package (`summer-engine`):
 
 All MIT, all free to use. One paste sets up all three.
 
-## Summer Cloud (new in 2.6.0)
-
-`summer cloud` syncs your whole game project across machines: scenes, scripts, settings, and the big binary assets that never fit in git. Files are stored by content hash, every push becomes a restorable version, and local checkpoints are taken before anything destructive touches your disk.
-
-```bash
-summer cloud init      # bind this project to your account
-summer cloud push      # upload what changed (only missing bytes travel)
-summer cloud pull      # make this machine match the cloud, verified by hash
-summer cloud status    # what differs between here and the cloud
-summer cloud restore   # roll the project back to any version
-```
-
-The same operations are available to agents as MCP tools (`summer_cloud_push`, `summer_cloud_pull`, and friends). See [www.summerengine.com/cloud](https://www.summerengine.com/cloud).
-
----
-
 ## Get started: one prompt
 
 Open your AI agent (Claude Code, Cursor, Codex, Copilot, Devin Desktop, etc.) and paste:
@@ -553,6 +537,24 @@ Skills evolve fast. Two ways to help:
 - [Skills overview](docs/SKILLS.md)
 - [Templates](docs/TEMPLATES.md)
 - [Architecture overview](docs/OVERVIEW.md)
+
+---
+
+## Research Preview: Summer Cloud
+
+Summer Cloud is an experimental R&D preview. It is optional, it may change or break, and it is **not** the core Summer CLI or MCP workflow. You do not need it to install or run Summer Engine, work with local projects, or use the local MCP server. The stable workflow is the local engine, CLI, MCP bridge, and agent skills described above.
+
+The preview explores content-addressed project sync across machines, including large assets that do not fit comfortably in git:
+
+```bash
+summer cloud init
+summer cloud status
+summer cloud push
+summer cloud pull
+summer cloud restore
+```
+
+Matching `summer_cloud_*` MCP tools are also experimental. Keep an independent backup and do not use this preview as the only recovery path for an important project. See [www.summerengine.com/cloud](https://www.summerengine.com/cloud).
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -255,61 +255,9 @@ Changing the CLI does NOT require rebuilding the engine. Rebuilding the engine d
 
 ### Release Checklist
 
-Full release = publish to npm + sync to public GitHub repo.
+A full release means the reviewed CLI changes and version bump are already on this repository's `main`, then npm is published from a fresh clone of that exact commit. Never publish first and commit source later.
 
-```bash
-cd tools/summer-cli
-
-# 1. Build and test
-npm run build
-bash scripts/smoke-test.sh
-
-# 2. Bump version
-npm version patch    # 0.1.0 -> 0.1.1 (bug fix)
-npm version minor    # 0.1.0 -> 0.2.0 (new feature)
-npm version major    # 0.1.0 -> 1.0.0 (breaking change)
-
-# 3. Publish to npm (requires 2FA OTP)
-npm publish --access public
-
-# 4. Verify the published package works
-npx summer-engine@latest status
-
-# 5. Sync to public GitHub repo
-#    Create a clean copy WITHOUT internal docs, then push.
-TMPDIR=$(mktemp -d)
-rsync -av \
-  --exclude='node_modules/' \
-  --exclude='dist/' \
-  --exclude='.DS_Store' \
-  --exclude='banner-preview.html' \
-  --exclude='docs/AGENT_EXPERIENCE_PRD.md' \
-  --exclude='docs/MCP_BUSINESS_STRATEGY.md' \
-  --exclude='docs/MCP_CLI_SECURITY_REVIEW_PLAN.md' \
-  --exclude='docs/MCP_PRICING_STRATEGY.md' \
-  --exclude='docs/MCP_PRODUCT_STRATEGY.md' \
-  --exclude='docs/HANDOFF.md' \
-  --exclude='docs/SKILLS_SYSTEM.md' \
-  --exclude='docs/specs' \
-  --exclude='docs/plans' \
-  ./ "$TMPDIR/"
-cd "$TMPDIR"
-git init
-git remote add origin git@github.com:SummerEngine/summer-engine-agent.git
-git fetch origin main
-git checkout -b main origin/main
-git add -A
-git commit -m "Release v$(node -p 'require("./package.json").version')"
-git push origin main
-cd -
-rm -rf "$TMPDIR"
-```
-
-**Before committing to the public repo, double-check:**
-- [ ] No internal URLs, pricing, or revenue numbers in any file
-- [ ] No references to private repos or internal docs
-- [ ] Commit message is clean - no internal context, no agent attribution
-- [ ] Internal strategy, pricing, security-review, handoff, spec, and plan docs are excluded
+Use [`RELEASING.md`](./RELEASING.md) for the release contract and [`NPM_PUBLISH_QUICK_COMMANDS.md`](./NPM_PUBLISH_QUICK_COMMANDS.md) for the copy-paste fresh-terminal procedure. Both contain hard stops for a stale version, a dirty tree, the wrong repository, or the wrong npm account.
 
 ### npm Account
 
@@ -417,6 +365,7 @@ The `api-token` changes each time the engine starts. If the MCP server cached an
 - [ ] Documentation for users (not devs) - the README is okay but there's no "Getting Started with MCP" tutorial that walks through the full flow with screenshots
 
 ### R&D / Future Investment
+- [ ] **Summer Cloud sync** - Experimental content-addressed project sync. Keep it clearly labeled as a Research Preview until recovery, conflicts, service availability, and cross-machine behavior have production evidence. It is not required for the stable local CLI and MCP workflow
 - [ ] **Simulated play (high value, hard problem)** - Let the AI start the game, simulate input (based on InputMap), record frames, and analyze what happens. This is the dream feedback loop: AI builds -> plays -> sees issues -> fixes. Blocked by: video-as-context is expensive and not well-supported by current models. Snapshot-per-frame is possible but noisy. Needs real R&D on frame sampling, input simulation via engine API, and cost-effective visual analysis
 - [ ] **Skills / knowledge packs** - Downloadable best-practice guides for game dev patterns (FPS, platformer, 3D optimization, GDScript patterns). Format TBD (markdown? Cursor rules? JSON?). Would make AI agents significantly better at building games
 

--- a/docs/NPM_PUBLISH_QUICK_COMMANDS.md
+++ b/docs/NPM_PUBLISH_QUICK_COMMANDS.md
@@ -1,0 +1,87 @@
+# Publish `summer-engine` from a fresh terminal
+
+This is the approved manual release path until trusted publishing is configured in this public repository. Run it yourself in an interactive macOS Terminal. Do not run the final publish through an AI shell.
+
+The version bump, changelog, and release contents must already be reviewed, committed, and merged to `SummerEngine/summer-engine-agent` `main`. This procedure intentionally makes no source changes.
+
+## 1. Clone the exact public source into a new directory
+
+```bash
+export RELEASE_DIR="$(mktemp -d)/summer-engine-agent"
+git clone --branch main --single-branch https://github.com/SummerEngine/summer-engine-agent.git "$RELEASE_DIR"
+cd "$RELEASE_DIR"
+git pull --ff-only origin main
+```
+
+Do not substitute an older checkout or a mirrored copy.
+
+## 2. Run the hard release gates
+
+Copy this whole block. It stops on the first mismatch.
+
+```bash
+set -e
+
+test "$(git branch --show-current)" = "main"
+test -z "$(git status --porcelain)"
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+
+export PACKAGE_NAME="$(node -p 'require("./package.json").name')"
+export PACKAGE_VERSION="$(node -p 'require("./package.json").version')"
+export LOCK_VERSION="$(node -p 'require("./package-lock.json").packages[""].version')"
+export REGISTRY_VERSION="$(npm view summer-engine dist-tags.latest)"
+
+test "$PACKAGE_NAME" = "summer-engine"
+test "$PACKAGE_VERSION" = "$LOCK_VERSION"
+
+node -e 'const [next,current]=process.argv.slice(1); const ok=/^\d+\.\d+\.\d+$/.test(next)&&/^\d+\.\d+\.\d+$/.test(current); const a=next.split(".").map(Number); const b=current.split(".").map(Number); const cmp=(a[0]-b[0])||(a[1]-b[1])||(a[2]-b[2]); if(!ok||cmp<=0){console.error(`STOP: package ${next} must be a new stable version greater than npm latest ${current}`);process.exit(1)}' "$PACKAGE_VERSION" "$REGISTRY_VERSION"
+
+printf 'Ready to validate %s@%s from %s\n' "$PACKAGE_NAME" "$PACKAGE_VERSION" "$(git rev-parse --short HEAD)"
+node --version
+npm --version
+```
+
+If this stops, do not improvise. Fix the version or source in a reviewed commit, merge it, delete this temporary clone, and start again from step 1.
+
+## 3. Install, test, build, and inspect the package
+
+```bash
+npm ci
+npm test
+npm run build
+npm pack --dry-run
+npm publish --dry-run
+git diff --exit-code
+test -z "$(git status --porcelain)"
+```
+
+The package scripts are:
+
+- Build: `npm run build`, which cleans `dist/` and compiles TypeScript.
+- Test: `npm test`, which runs Vitest once.
+- Publish guard: `prepublishOnly`, which runs the build and tests again immediately before a real publish.
+- Publish: `npm publish`. `publishConfig` pins the public npm registry and public access.
+
+Read the dry-run file list. Stop if it contains secrets, `.env` files, internal planning documents, or if expected CLI files, skills, and `dist/bin/summer.js` are missing.
+
+## 4. Authenticate and publish
+
+```bash
+npm login --auth-type=web
+test "$(npm whoami)" = "summer-engine"
+npm publish
+```
+
+The browser flow must authenticate the `summer-engine` npm account with its configured security key. npm may prompt for the security key again when publishing. If the account name is different, authentication fails, or npm requests a factor you do not have, stop. Do not disable 2FA and do not create a bypass token for a one-off manual release.
+
+Success ends with `+ summer-engine@<version>`.
+
+## 5. Verify the exact release
+
+```bash
+test "$(npm view "summer-engine@$PACKAGE_VERSION" version)" = "$PACKAGE_VERSION"
+test "$(npm view summer-engine dist-tags.latest)" = "$PACKAGE_VERSION"
+npx -y "summer-engine@$PACKAGE_VERSION" --version
+```
+
+Keep the terminal output with the release record. The temporary clone can be deleted after verification.

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -119,3 +119,7 @@ The agent layer is open so you can audit, fork, and extend. The engine is the mo
 ```
 
 The left column — skills + MCP + CLI — is what this repo ships. The bottom box is Summer Engine, which you download and run separately.
+
+## Research previews
+
+`summer cloud` and the matching `summer_cloud_*` MCP tools are an experimental R&D preview. They are optional and are not part of the core local CLI, engine, skills, or MCP workflow shown above. Expect the preview surface and behavior to change, and keep an independent backup for important projects.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,185 +1,73 @@
-# Releasing summer-engine
+# Releasing `summer-engine`
 
-Step-by-step runbook for publishing a new version of `summer-engine` to npm.
+The npm package is `summer-engine`. This repository is its public source, and its binary is `summer`.
 
-## Pre-flight
+For the exact copy-paste procedure, use [`NPM_PUBLISH_QUICK_COMMANDS.md`](./NPM_PUBLISH_QUICK_COMMANDS.md). It publishes only from a clean, fresh clone of public `main` and stops if the candidate version is not newer than npm `latest`.
 
-1. All commits merged to `main` on the engine repo (`SummerEngine/SummerEngine`).
-2. `npm test` passes (`cd tools/summer-cli && npm test`).
-3. `npm run build` succeeds.
-4. Plugin manifests (`.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.codex-plugin/plugin.json`) and `marketplace.json` already bumped to the target version. (Done in feature commits, not at release time.)
+## Required before 2.6.6
 
-## Bump version
+Reconcile the CLI protocol changes from engine PR 13 merge commit `b7a3e28245f8784d28a9f7b7e35524e0c9ccc814` before preparing the 2.6.6 version bump. The affected package files are `src/lib/api-client.ts`, `src/lib/api-client.test.ts`, and `src/lib/cloud/engine-bridge.ts`. Preserve the newer public 2.6.5 work while bringing those protocol changes across.
 
-```powershell
-cd "<SummerEngine checkout>/tools/summer-cli"
-```
+Do not bump or publish 2.6.6 until that reconciliation has its own review and tests.
 
-Edit `package.json` `version` field manually, or use:
+## Release contract
 
-```powershell
-npm version <patch|minor|major> --no-git-tag-version
-```
+1. Reconcile all approved CLI work into this repository without overwriting newer public changes.
+2. Bump `package.json` and `package-lock.json` to the same new semver version and update `CHANGELOG.md` in a reviewed commit.
+3. Merge that commit to `main` before publishing.
+4. Run the fresh-terminal procedure from a new clone.
+5. Verify the exact version and the `latest` dist-tag from npm after publishing.
 
-Match the version to whatever the plugin manifests are at. Don't let npm version drift from manifest version.
+Never publish an uncommitted version bump. npm never allows the same package name and version to be reused, even after unpublishing.
 
-## Build + dry-run
+## Package commands
 
-```powershell
-npm run build
-npm publish --dry-run
-```
+These commands come from `package.json`:
 
-The dry-run prints the tarball contents. Verify:
-- `total files` is roughly the expected count (currently ~198)
-- `version` matches what you set
-- New skill files / commands appear in the file list
-- No secrets, no `.env`, no internal docs (`docs/MCP_*_STRATEGY.md`, `docs/specs/`, `docs/plans/`)
+| Purpose | Command | Effect |
+|---|---|---|
+| Reproducible install | `npm ci` | Installs exactly from `package-lock.json` |
+| Build | `npm run build` | Removes `dist/` and runs TypeScript compilation |
+| Test | `npm test` | Runs the Vitest suite once |
+| Package inspection | `npm pack --dry-run` | Shows the files npm would ship |
+| Publish simulation | `npm publish --dry-run` | Runs the publish lifecycle without uploading |
+| Publish | `npm publish` | Runs `prepublishOnly`, then uploads to npm |
 
-## Publish
+`prepublishOnly` is `npm run build && npm test`, so the real publish repeats both checks immediately before upload. `publishConfig` fixes the target to `https://registry.npmjs.org` with public access.
 
-**Use `--auth-type=web`. It bypasses the OTP requirement entirely.** Run from your interactive PowerShell / Terminal — NOT from the AI agent's shell. The CLI prints a URL and waits for you to press ENTER, which only works in an interactive TTY.
+## Authentication and signing
 
-Run these as **two separate lines** (don't chain with `;` or `&&` — copy each line by itself):
+The current approved path is an interactive manual publish:
 
-```powershell
-cd "<SummerEngine checkout>/tools/summer-cli"
-```
+- Sign in with `npm login --auth-type=web`.
+- Confirm `npm whoami` is exactly `summer-engine`.
+- Complete the configured security-key 2FA prompt during login or publish.
+- Do not disable 2FA or create a bypass token for a manual release.
 
-```powershell
-npm publish --auth-type=web
-```
+npm requires either account 2FA for an interactive publish or a granular access token with bypass 2FA for automation. See npm's [2FA publishing requirements](https://docs.npmjs.com/requiring-2fa-for-package-publishing-and-settings-modification/) and [browser login flow](https://docs.npmjs.com/accessing-npm-using-2fa/).
 
-A browser tab opens. Click "Confirm" to approve the publish. Output ends with `+ summer-engine@<version>` on success.
+No Apple or Windows application-signing certificate is involved in the npm package. npm adds its registry signature to published tarballs automatically. A manual publish does **not** create Sigstore provenance.
 
-### Why two lines, not one chained
+## Provenance and trusted publishing
 
-Past experience: `cd "..."; npm publish` works in PowerShell, but if anything in the path has surprising chars (spaces, accents) the chained form gets parsed wrong. Two lines is safer and lets you eyeball the `cd` succeeded before publishing.
+Trusted publishing is not the current release path. Before enabling it, configure npm to trust an exact workflow in this public repository and review the workflow separately.
 
-### Why an interactive shell
+Current npm requirements include:
 
-`--auth-type=web` does:
-1. Opens a `https://www.npmjs.com/auth/cli/<id>` URL in your browser.
-2. Prints "Press ENTER to open in the browser..." and waits for stdin.
-3. Once you confirm in the browser, the CLI exits with the publish.
+- A GitHub-hosted runner in the public repository named by `package.json`.
+- `permissions: id-token: write` for OIDC.
+- Node.js 22.14 or newer and npm 11.5.1 or newer for trusted publishing.
+- The exact repository and workflow filename configured as the package's trusted publisher on npm.
 
-If run from a non-interactive shell (e.g. an AI agent's `Bash` tool), step 2's stdin wait fails — the CLI falls back to asking for OTP and errors with `EOTP`. So always run the publish yourself from PowerShell or Terminal, not via the agent.
+Trusted publishing uses short-lived OIDC credentials and automatically creates provenance for a public package published from a public repository. See npm's [trusted publishing](https://docs.npmjs.com/trusted-publishers/) and [provenance](https://docs.npmjs.com/generating-provenance-statements/) documentation.
 
-### Why `--auth-type=web` and not just `npm publish`
+## Recovery after a bad release
 
-The `summer-engine` npm account has 2FA enabled with a security key on a different machine (MacBook). On any other machine, plain `npm publish` will fail with `EOTP — This operation requires a one-time password from your authenticator` because:
+Prefer a patch-forward release:
 
-1. There's no authenticator app configured (only a hardware security key on the MacBook).
-2. The token in `~/.npmrc` is a classic token — classic tokens do NOT bypass 2FA-on-publish.
-3. Disabling 2FA at account-level, package-level, or org-level only partially helps because npm enforces 2FA-on-publish from multiple sources independently.
+1. Fix the issue.
+2. Bump to a new patch version.
+3. Review and merge it.
+4. Repeat the fresh-terminal runbook.
 
-`--auth-type=web` sidesteps all of that. npm CLI prints a `https://www.npmjs.com/auth/cli/<id>` URL, you open it in any browser where you're already logged into npm, click "Confirm", publish completes. **Two seconds, no OTP, no token gymnastics.**
-
-This requires npm CLI 9+ (you're fine — Node 18+ ships with this).
-
-### What NOT to do (lessons learned 2026-05-10)
-
-- **Don't try to disable account-level 2FA** to skip OTP — it's blocked by org membership requirements and only partially affects publish.
-- **Don't try to disable package-level 2FA** unless you have a specific reason — `--auth-type=web` is faster.
-- **Don't generate granular access tokens for one-off publishes.** They're correct for CI/CD, but for a manual publish from your dev machine, `--auth-type=web` is one command.
-- **Don't run `npm publish` from the wrong directory** — npm scans the current dir for `package.json`. Running from `~` will scan your entire home directory and trip on weird files (e.g. Docker named pipes → `EACCES`).
-- **Don't `npm install -g summer-engine`** to test the publish — use `npx -y summer-engine@<version>` instead. No PATH pollution, no sudo.
-
-## Verify the publish landed
-
-```powershell
-curl https://registry.npmjs.org/summer-engine/latest
-```
-
-Should show the new version. Or browse to https://www.npmjs.com/package/summer-engine.
-
-## Commit the version bump
-
-```powershell
-cd "<SummerEngine checkout>"
-git add tools/summer-cli/package.json tools/summer-cli/docs/RELEASING.md
-git commit -m "chore(release): summer-engine v<X.Y.Z>"
-git push origin main
-```
-
-## Sync to public repo
-
-If the engine repo is the source of truth and `SummerEngine/summer-engine-agent` is the public mirror, sync via the existing tar-copy script (see `docs/DEVELOPMENT.md`).
-
-## Rollback
-
-You can't unpublish a version after 72 hours. If a bug ships:
-
-1. **Patch forward**: bump to `<X.Y.Z+1>`, fix, republish. This is almost always the right answer.
-2. **Deprecate**: `npm deprecate summer-engine@<bad-version> "use <good-version>"`.
-3. **Within 72 hours, you can `npm unpublish summer-engine@<version>`** — but this breaks downstream installs that already pinned to it. Almost never the right choice.
-
-## Version drift detection
-
-As of v2.4.0, `summer doctor --json` reports two new checks that catch the
-"user is on a stale CLI / skills snapshot" failure mode without bothering the
-user:
-
-- **`cli-version-current`** — fetches `https://registry.npmjs.org/summer-engine/latest`
-  with a 3 s timeout and compares against the installed `package.json` version.
-  - `ok` if installed >= latest, or only differs on patch (so `2.4.0` vs
-    `2.4.5` is fine — patches are inconsequential and we don't want users to
-    see an "update me" message every time we ship a hotfix).
-  - `warning` if one minor behind (`2.4.0` vs `2.5.0`).
-  - `fail` if 2+ minors or any major-version drift behind (`2.4.0` vs `2.6.0`
-    or `3.0.0`).
-  - On network error / timeout / non-200 response: returns `ok` with
-    `details.reason: "registry-unreachable"`. We never false-alarm an offline
-    user.
-
-- **`skills-version-stale`** — reads a `.summer-version` marker dropped into
-  the user's skill install dir whenever `summer skills install` runs. Compares
-  the marker's recorded version to the running CLI's version, with the same
-  ok/warning/fail thresholds as above. If multiple agents have markers and
-  several are stale, the worst (most-stale) one wins so we surface the largest
-  drift to the user. If no marker exists at all, the check returns `ok` with
-  `reason: "no-marker"` so a brand-new install isn't flagged.
-
-The agent's playbook (Step 0 of the README) parses `details.recommendedAction`
-on warning/fail and re-runs the install with `--force` automatically. End
-result: the agent sees stale state, refreshes silently, the user only hears
-about it via a single one-liner ("There's a newer Summer (2.4.0 → 2.5.0);
-updating before we start.") instead of being asked to make a choice.
-
-### Manual force update
-
-If a user wants to bypass the playbook and update directly:
-
-```bash
-npx clear-npx-cache && npx -y summer-engine@latest setup <agent> --yes --force
-```
-
-`<agent>` is `claude-code`, `cursor`, `codex`, `windsurf`, `cline`, `roo-code`,
-`kilo-code`, `gemini`, `github-copilot`, `vscode-copilot`, `opencode`, or `lm-studio`.
-
-### Patch hotfixes don't trigger update prompts
-
-Bumping `2.4.0 → 2.4.1` for a bug fix is silent — `cli-version-current` returns
-`ok` with `reason: "patch-only"` so users don't see churn for inconsequential
-changes. Save `warning` and `fail` for minor and major bumps where the agent
-behaviour or the skill catalog actually moved.
-
-## CI/CD (future)
-
-When ready to automate publishes from GitHub Actions:
-
-1. Generate a **granular access token** at https://www.npmjs.com/settings/~/tokens/new
-   - Name: `github-actions-publish`
-   - Expiration: 1 year (regenerate annually)
-   - Packages: `summer-engine`
-   - Permissions: Read and write
-   - **Bypass two-factor authentication: ON**
-2. Store as `NPM_TOKEN` in GitHub Actions secrets.
-3. Workflow snippet:
-   ```yaml
-   - run: npm publish
-     env:
-       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-   ```
-
-Until CI is wired, the manual `npm publish --auth-type=web` flow above is the canonical path.
+If necessary, deprecate a broken version with `npm deprecate summer-engine@<bad-version> "use <good-version>"`. Avoid unpublishing because consumers may already depend on that immutable version.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,12 +4,6 @@ The npm package is `summer-engine`. This repository is its public source, and it
 
 For the exact copy-paste procedure, use [`NPM_PUBLISH_QUICK_COMMANDS.md`](./NPM_PUBLISH_QUICK_COMMANDS.md). It publishes only from a clean, fresh clone of public `main` and stops if the candidate version is not newer than npm `latest`.
 
-## Required before 2.6.6
-
-Reconcile the CLI protocol changes from engine PR 13 merge commit `b7a3e28245f8784d28a9f7b7e35524e0c9ccc814` before preparing the 2.6.6 version bump. The affected package files are `src/lib/api-client.ts`, `src/lib/api-client.test.ts`, and `src/lib/cloud/engine-bridge.ts`. Preserve the newer public 2.6.5 work while bringing those protocol changes across.
-
-Do not bump or publish 2.6.6 until that reconciliation has its own review and tests.
-
 ## Release contract
 
 1. Reconcile all approved CLI work into this repository without overwriting newer public changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "summer-engine",
-  "version": "2.6.4",
+  "version": "2.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "summer-engine",
-      "version": "2.6.4",
+      "version": "2.6.6",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "summer-engine",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "description": "Local Summer CLI and MCP server for Summer Engine. Install and run the engine, connect Claude Code, Cursor, Codex, Gemini, and other agents, and build real games with bundled skills, hooks, and plugins.",
   "keywords": [
     "summer-engine",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "summer-engine",
   "version": "2.6.5",
-  "description": "Summer CLI and MCP server for Summer Engine, the AI game engine. Install the engine, connect Claude Code, Cursor, Codex, Gemini, and other agents, and build real games. Skills, hooks, and plugins included.",
+  "description": "Local Summer CLI and MCP server for Summer Engine. Install and run the engine, connect Claude Code, Cursor, Codex, Gemini, and other agents, and build real games with bundled skills, hooks, and plugins.",
   "keywords": [
     "summer-engine",
     "summer-cli",
@@ -26,6 +26,10 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/SummerEngine/summer-engine-agent.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
   },
   "license": "MIT",
   "author": "Summer Engine <founders@summerengine.com>",

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -41,6 +41,59 @@ const client = () => new EngineApiClient(6550, "test-token");
 afterEach(() => vi.unstubAllGlobals());
 
 describe("EngineApiClient — async 202->poll port", () => {
+  it("pins every request to the engine and project captured at connect time", async () => {
+    const seen: string[] = [];
+    mockFetch((url) => {
+      seen.push(url);
+      return json({ nodes: [] });
+    });
+    const scoped = new EngineApiClient(6550, "test-token", {
+      instanceId: "engine-a",
+      projectId: "project-a",
+      projectIdHash: "hash-a",
+    });
+
+    await scoped.getSceneState();
+
+    const url = new URL(seen[0]);
+    expect(url.searchParams.get("instanceId")).toBe("engine-a");
+    expect(url.searchParams.get("projectId")).toBe("project-a");
+    expect(url.searchParams.get("projectIdHash")).toBe("hash-a");
+    expect(url.searchParams.get("projectIdentityVersion")).toBe("1");
+  });
+
+  it("updates the complete request identity after an explicit rebind", async () => {
+    const seen: string[] = [];
+    mockFetch((url) => {
+      if (url.includes("/api/health")) {
+        return json({
+          ok: true,
+          engine: "summer",
+          version: "0.5.43",
+          instanceId: "engine-b",
+          projectId: "project-b",
+          projectIdHash: "hash-b",
+        });
+      }
+      seen.push(url);
+      return json({ nodes: [] });
+    });
+    const scoped = new EngineApiClient(6550, "test-token", {
+      instanceId: "engine-a",
+      projectId: "project-a",
+      projectIdHash: "hash-a",
+    });
+
+    await expect(scoped.rebind()).resolves.toBe("hash-b");
+    await scoped.getSceneState();
+
+    const url = new URL(seen[0]);
+    expect(url.searchParams.get("instanceId")).toBe("engine-b");
+    expect(url.searchParams.get("projectId")).toBe("project-b");
+    expect(url.searchParams.get("projectIdHash")).toBe("hash-b");
+    expect(url.searchParams.get("projectIdentityVersion")).toBe("1");
+  });
+
   it("executeOps resolves the TERMINAL apply result via poll, not the queued ack", async () => {
     mockFetch((url, method) => {
       if (method === "POST" && url.includes("/api/ops")) {

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -62,6 +62,12 @@ type SnapshotPayload = Record<string, unknown> & {
   used_synthetic_camera?: boolean;
 };
 
+type EngineTargetIdentity = {
+  instanceId?: string;
+  projectId?: string;
+  projectIdHash?: string;
+};
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -142,18 +148,24 @@ function withoutImageData(payload: SnapshotPayload): Record<string, unknown> {
 export class EngineApiClient {
   private port: number;
   private token: string;
-  // The project this session is BOUND to — the projectIdHash reported by the
-  // engine when this client first connected. Sent on every mutating op so the
-  // engine's identity guard (local_api_server.cpp ~271-302) atomically rejects a
-  // write aimed at a DIFFERENT project (e.g. after the user switched projects
-  // in-place). Health is the only identity signal the MCP has — /api/state/project
-  // carries no path and /api/health exposes only projectIdHash, not the raw id.
-  private boundProjectIdHash?: string;
+  // The engine and project this session is bound to. Every request carries the
+  // identity captured from health so the engine can reject requests after an
+  // in-place project switch or an unexpected instance change. The string form
+  // preserves the pre-2.6.6 constructor contract for existing callers that only
+  // supplied a projectIdHash.
+  private targetIdentity: EngineTargetIdentity;
 
-  constructor(port: number, token: string, boundProjectIdHash?: string) {
+  constructor(
+    port: number,
+    token: string,
+    targetIdentity: EngineTargetIdentity | string = {}
+  ) {
     this.port = port;
     this.token = token;
-    this.boundProjectIdHash = boundProjectIdHash;
+    this.targetIdentity =
+      typeof targetIdentity === "string"
+        ? { projectIdHash: targetIdentity }
+        : { ...targetIdentity };
   }
 
   static async connect(): Promise<EngineApiClient> {
@@ -178,34 +190,57 @@ export class EngineApiClient {
     // rebinds to the current project. An in-place project switch keeps the same
     // token, so the cached client retains its original binding and the engine
     // rejects mismatched mutations until the agent explicitly rebinds.
-    return new EngineApiClient(port, token, health.projectIdHash);
+    return new EngineApiClient(port, token, {
+      instanceId: health.instanceId,
+      projectId: health.projectId,
+      projectIdHash: health.projectIdHash,
+    });
   }
 
   /** The projectIdHash this session is bound to (undefined if none was reported
    *  at connect — e.g. no project open yet). */
   getBoundProjectIdHash(): string | undefined {
-    return this.boundProjectIdHash;
+    return this.targetIdentity.projectIdHash;
   }
 
   /**
    * Re-read health and rebind to the currently-open project. Called by
    * summer_get_project_context so the agent can INTENTIONALLY follow a project
    * switch (the deliberate escape hatch after an identity_mismatch). Returns the
-   * new bound hash. Reads carry no identity, so this always reaches the engine
-   * even when a mutation would be rejected.
+   * new bound hash. The direct health probe is intentionally unscoped, so it can
+   * reach the current engine even when bound requests would be rejected.
    */
   async rebind(): Promise<string | undefined> {
     const health = await checkEngineHealth(this.port);
     if (health) {
-      this.boundProjectIdHash = health.projectIdHash;
+      this.targetIdentity = {
+        instanceId: health.instanceId,
+        projectId: health.projectId,
+        projectIdHash: health.projectIdHash,
+      };
     }
-    return this.boundProjectIdHash;
+    return this.targetIdentity.projectIdHash;
   }
 
   /** Identity to attach to a MUTATING command's options so the engine can reject
    *  a wrong-project write. Empty when unbound (engine then skips the check). */
   private identityOptions(): Record<string, unknown> {
-    return this.boundProjectIdHash ? { projectIdHash: this.boundProjectIdHash } : {};
+    const projectIdHash = this.targetIdentity.projectIdHash;
+    return projectIdHash ? { projectIdHash } : {};
+  }
+
+  private targetUrl(path: string): string {
+    const url = new URL(path, `http://127.0.0.1:${this.port}`);
+    const { instanceId, projectId, projectIdHash } = this.targetIdentity;
+
+    if (instanceId) url.searchParams.set("instanceId", instanceId);
+    if (projectId) url.searchParams.set("projectId", projectId);
+    if (projectIdHash) url.searchParams.set("projectIdHash", projectIdHash);
+    if (instanceId && projectId && projectIdHash) {
+      url.searchParams.set("projectIdentityVersion", "1");
+    }
+
+    return url.toString();
   }
 
   private async request(
@@ -213,7 +248,7 @@ export class EngineApiClient {
     path: string,
     body?: unknown
   ): Promise<unknown> {
-    const url = `http://127.0.0.1:${this.port}${path}`;
+    const url = this.targetUrl(path);
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.token}`,
       "Content-Type": "application/json",
@@ -242,7 +277,7 @@ export class EngineApiClient {
     body: unknown,
     timeoutMs: number
   ): Promise<Response> {
-    return fetch(`http://127.0.0.1:${this.port}${path}`, {
+    return fetch(this.targetUrl(path), {
       method,
       headers: {
         Authorization: `Bearer ${this.token}`,
@@ -461,18 +496,17 @@ export class EngineApiClient {
     const buffer = Buffer.from(base64, "base64");
     const localPath = await this.writeSnapshotFile(kind, buffer, ext);
 
-    // Client-side identity drift check (item 4). The engine's identity guard only
-    // acts on options.projectIdHash inside a queued command; a GET snapshot from
-    // `fetch` carries no reliable body, so we cannot count on the engine to reject
-    // a drifted read. Re-read health and compare to the bound hash — if the engine
-    // has switched projects since we bound, this frame may be from the WRONG
-    // project. Best-effort: a failed health read never blocks the (already
-    // captured) image.
+    // Client-side identity drift check (item 4). Current engines validate the
+    // identity query on snapshot reads, but older builds may ignore it. Re-read
+    // health and compare to the bound hash so a frame from a switched project is
+    // still marked as suspect. Best-effort: a failed health read never blocks the
+    // already captured image.
     let projectMismatch: boolean | undefined;
-    if (this.boundProjectIdHash) {
+    const boundProjectIdHash = this.targetIdentity.projectIdHash;
+    if (boundProjectIdHash) {
       try {
         const health = await checkEngineHealth(this.port);
-        if (health?.projectIdHash && health.projectIdHash !== this.boundProjectIdHash) {
+        if (health?.projectIdHash && health.projectIdHash !== boundProjectIdHash) {
           projectMismatch = true;
         }
       } catch {

--- a/src/lib/cloud/engine-bridge.ts
+++ b/src/lib/cloud/engine-bridge.ts
@@ -54,7 +54,15 @@ async function connectForProject(projectRoot: string): Promise<EngineSession | n
     // A different project's engine instance must never be asked to save or
     // rescan; the executor rejects mismatches too, but skip the round trip.
     if (health.projectIdHash && health.projectIdHash !== projectIdHash) return null;
-    return { client: new EngineApiClient(port, token), projectIdHash, scene: health.scene };
+    return {
+      client: new EngineApiClient(port, token, {
+        instanceId: health.instanceId,
+        projectId: health.projectId,
+        projectIdHash,
+      }),
+      projectIdHash,
+      scene: health.scene,
+    };
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- pin instance, project ID, and project hash on all engine requests
- keep newer rebind, mutation, screenshot, and capture safeguards
- move Summer Cloud to an optional Research Preview near the bottom
- prepare version 2.6.6 and a guarded human npm publish runbook

## Checks
- independent release review clean
- focused API tests passed
- full CLI tests passed
- build passed
- npm package dry run passed

This PR does not publish to npm.