### PR TITLE
feat(cli): ship Summercraft creator publish client

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "summer",
   "version": "2.5.1",
-  "description": "Agent tooling for Summer Engine: game-dev skills, lifecycle hooks, and a 56-tool MCP bridge to the local desktop app.",
+  "description": "Summer SDK agent tooling: game-dev skills, lifecycle hooks, and a 62-tool MCP bridge for making Summer games.",
   "author": {
     "name": "Summer Engine",
     "email": "founders@summerengine.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "summer",
   "version": "2.5.1",
-  "description": "Agent tooling for Summer Engine: game-dev skills, lifecycle hooks, and a 56-tool MCP bridge. Build games by talking.",
+  "description": "Agent tooling for Summer Engine: game-dev skills, lifecycle hooks, and a 62-tool MCP bridge. Build games by talking.",
   "author": {
     "name": "Summer Engine",
     "email": "founders@summerengine.com",
@@ -95,7 +95,7 @@
   "interface": {
     "displayName": "Summer",
     "shortDescription": "Superpowers for AI game dev. Build games by talking.",
-    "longDescription": "Summer turns Codex into a game-dev studio for Summer Engine, the AI-native game engine. It adds game-dev skills, lifecycle hooks, and a 56-tool MCP bridge for guarded project files, scene editing, asset import, play mode, diagnostics, and generation. Git, shell, and grep stay with the host agent. Summer Engine is compatible with Godot 4.5. Write code in GDScript and drive project mutations through MCP. Session-start orients the session. Pre-commit doctor (opt-in) blocks bad commits.",
+    "longDescription": "Summer turns Codex into a game-dev studio for Summer Engine. It adds game-dev skills, lifecycle hooks, and a 62-tool MCP bridge for guarded project files, scene editing, asset import, play mode, diagnostics, generation, and creator workflows. Git, shell, and grep stay with the host agent. Make Summer games in GDScript and drive project mutations through MCP. Summer follows its upstream technical base continuously; version-sensitive work uses the bundled compatibility reference. Session-start orients the session. Pre-commit doctor (opt-in) blocks bad commits.",
     "developerName": "Summer Engine",
     "category": "Coding",
     "capabilities": ["Interactive", "Read", "Write"],

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "summer",
   "displayName": "Summer",
   "version": "2.5.1",
-  "description": "Agent tooling for Summer Engine: game-dev skills, lifecycle hooks, and a 56-tool MCP bridge to the local desktop app.",
+  "description": "Summer SDK agent tooling: game-dev skills, lifecycle hooks, and a 62-tool MCP bridge for making Summer games.",
   "author": { "name": "Summer Engine", "email": "founders@summerengine.com" },
   "publisher": "summer-engine",
   "homepage": "https://summerengine.com",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,13 @@ This file is for any AI agent that loads context from `AGENTS.md` (Codex CLI, Fa
 
 ## What you're working with
 
-**Summer Engine** is the AI-native game engine the user is building in. Editor, scene graph, asset pipeline, and runtime are all instrumented for programmatic control via the `summer-engine` MCP server. Summer Engine is compatible with Godot 4.5 — projects use GDScript (`.gd`), C# (`.cs`), scenes (`.tscn`/`.scn`), and resources (`.tres`/`.res`). Write code in those languages; talk to the engine through MCP tools.
+**Summer Engine** is the AI-native game engine the user is building in. They
+are making a **Summer game** with the **Summer SDK**. Editor, scene graph,
+asset pipeline, and runtime are instrumented for programmatic control via the
+`summer-engine` MCP server. GDScript (`.gd`) is the default language; C#
+(`.cs`), scenes (`.tscn`/`.scn`), and resources (`.tres`/`.res`) are also
+supported. Talk to the engine through Summer MCP tools. Use the bundled
+technical compatibility reference for version-sensitive upstream APIs.
 
 ## Critical rules
 
@@ -25,7 +31,7 @@ This file is for any AI agent that loads context from `AGENTS.md` (Codex CLI, Fa
 
 ## MCP tool palette (engine on `localhost:6550`)
 
-56 tools total. Categories:
+62 tools total. Categories:
 
 - Scene: `summer_get_scene_tree`, `summer_open_scene`, `summer_create_scene`, `summer_add_node`, `summer_set_prop`, `summer_set_resource_property`, `summer_remove_node`, `summer_save_scene`, `summer_instantiate_scene`, `summer_replace_node`, `summer_select_node`, `summer_inspect_node`, `summer_inspect_resource`, `summer_connect_signal`, `summer_batch`.
 - Diagnostics: `summer_create_debug_report`, `summer_get_script_errors`, `summer_get_diagnostics`, `summer_get_console`, `summer_clear_console`, `summer_get_debugger_errors`, `summer_get_debugger_warnings`.
@@ -36,6 +42,7 @@ This file is for any AI agent that loads context from `AGENTS.md` (Codex CLI, Fa
 - Assets: `summer_search_assets`, `summer_list_my_assets`, `summer_get_asset`, `summer_get_asset_download_url`, `summer_import_asset`, `summer_import_asset_by_id`, `summer_import_from_url`, `summer_import_from_url_batch`.
 - Generation: `summer_generate_image`, `summer_generate_3d`, `summer_generate_audio`, `summer_generate_video`, `summer_generate_motion`, `summer_check_job`.
 - Meta: `summer_start_game_task`.
+- Creator: `summer_creator_publish`, `summer_creator_releases`, `summer_creator_logs`, `summer_creator_config`.
 
 Git, shell, and grep are not exposed. Project file reads and writes are exposed through identity-bound Summer tools; do not bypass them with host writes when MCP is available. External host tools cannot be technically blocked, so the agent must follow this rule.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,7 +4,12 @@ Summer is the AI game-dev studio for **Summer Engine** — the AI-native game en
 
 ## What Summer Engine is
 
-A game engine designed for AI agents — editor, scene graph, asset pipeline, and runtime are all instrumented for programmatic control via MCP. Summer Engine is compatible with Godot 4.5: projects use GDScript (`.gd`), C# (`.cs`), scenes (`.tscn`/`.scn`), and resources (`.tres`/`.res`). Write code in those languages; talk to the engine through `summer_*` tools.
+A game engine designed for AI agents. The user is making a **Summer game**
+with the **Summer SDK**. Editor, scene graph, asset pipeline, and runtime are
+instrumented for programmatic control via MCP. GDScript (`.gd`) is the default
+language; C# (`.cs`), scenes (`.tscn`/`.scn`), and resources (`.tres`/`.res`)
+are also supported. Talk to the engine through `summer_*` tools, and use the
+bundled technical compatibility reference for version-sensitive upstream APIs.
 
 ## How to behave
 
@@ -20,7 +25,7 @@ The single most important skill to know is `summer:using-summer` — it explains
 
 ## MCP tools (when the engine is running on `localhost:6550`)
 
-The `summer-engine` MCP server exposes 56 focused tools. The most important:
+The `summer-engine` MCP server exposes 62 tools. The most important:
 
 - **Scene mutation**: `summer_add_node`, `summer_set_prop`, `summer_set_resource_property`, `summer_remove_node`, `summer_save_scene`, `summer_replace_node`, `summer_batch`. Every scene mutation requires the exact `res://...tscn` `scenePath`; opening a scene is a user-visible UI action, not a mutation prerequisite. Mutation tools append one final `SaveScene`; raw engine batches must do the same.
 - **Scene inspection**: `summer_get_scene_tree`, `summer_inspect_node`, `summer_inspect_resource`.
@@ -35,7 +40,7 @@ Git, shell, and grep remain host-native. Use the Summer file tools for project r
 
 ## Type-system traps
 
-`SetProp` values are engine-formatted **strings** (Godot 4.5 type-system compatible):
+`SetProp` values are Summer Engine-formatted **strings**:
 
 - `"Vector3(0, 10, 0)"` — NOT `{x: 0, y: 10, z: 0}`.
 - `"Color(1, 0.5, 0, 1)"` — RGBA, 4 components.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Summer Engine: the AI game engine
 
-> **Engine mirror only.** This directory is intentionally marked `private` and must never be published to npm. Review and reconcile changes into [SummerEngine/summer-engine-agent](https://github.com/SummerEngine/summer-engine-agent), which is the only npm release source.
-
-Build real 2D and 3D games through conversation. No coding required. Export to Steam, desktop, mobile, and web. Built on the Godot team's work, customized and honed so AI agents and humans can collaborate on great games.
+Build real 2D and 3D Summer games through conversation. Start visually or in
+GDScript and collaborate with AI agents through the Summer SDK. Public Summer
+Engine installers currently ship for macOS on Apple silicon and Windows;
+Steam, browser, mobile, and additional desktop distribution are planned
+targets, not shipping promises.
 
 **Summer** is the MIT open-source agent layer that connects your AI coding agent to Summer Engine. It is the **Summer CLI**, the **Summer MCP** server, and the **Summer agent** skills, hooks, and plugin manifests, all in one package. First-class setup works in Claude Code, Cursor, Codex, Devin Desktop (formerly Windsurf), Cline, Roo Code, Gemini CLI, GitHub Copilot CLI, GitHub Copilot in VS Code, and OpenCode. Factory Droid uses the plugin marketplace path.
 
@@ -20,7 +22,7 @@ It just works. Open your agent, say *"let's make an FPS in Summer Engine,"* and 
 Three names, one npm package (`summer-engine`):
 
 - **Summer CLI** (`npx -y summer-engine@latest`): installs the engine, signs you in, scaffolds and runs projects, and writes your agent's config. See [www.summerengine.com/cli](https://www.summerengine.com/cli).
-- **Summer MCP**: the local MCP server that gives your agent 56 engine tools to build, run, and debug a real game. See [www.summerengine.com/mcp](https://www.summerengine.com/mcp).
+- **Summer MCP**: the MCP server that gives your agent 62 tools spanning local engine work, cloud workflows, and creator publishing. See [www.summerengine.com/mcp](https://www.summerengine.com/mcp).
 - **Summer agent layer**: the game-dev skills, hooks, and plugin manifests that give your AI agent judgment, not just a chat box.
 
 All MIT, all free to use. One paste sets up all three.
@@ -102,7 +104,10 @@ npx -y summer-engine@latest install
 
 ~1 GB. Downloads from Summer's signed releases. The bundle includes the engine binary plus Git and a handful of other runtime tools so users who don't already have them aren't blocked. The CLI prints the URL and size before touching disk. Tell the user **"downloading the engine app, ~1 GB, this takes a couple minutes"** so they don't bail thinking it stalled.
 
-**Linux note:** the engine app currently supports macOS and Windows only. On Linux, `summer install` exits with a "Linux support coming soon" message. Surface the manual download URL to the user (https://summerengine.com/download) and stop. The rest of the playbook still works once they've installed manually.
+**Linux note:** there is no supported public Linux installer. On Linux,
+`summer install` exits with a "Linux support coming soon" message. Tell the
+user Linux support is planned and stop; do not imply that a manual Linux
+engine download is available.
 
 ### Step 3: Sign in (only if `login` needs attention)
 
@@ -218,6 +223,7 @@ We tell you before we touch your disk.
 | `summer-engine` npm package (CLI + plugin source) | ~3 MB | first `npx -y summer-engine@latest ...` call | [npmjs.com/package/summer-engine](https://www.npmjs.com/package/summer-engine) |
 | Summer Engine app | ~1 GB (engine + bundled Git/runtime tools) | `npx -y summer-engine@latest install` | Summer's signed releases |
 | Auth token | ~1 KB | `npx -y summer-engine@latest login` | Browser to `~/.summer/auth-token` |
+| Creator token | ~50 bytes | only after `summer login --creator` and explicit token minting | One-time browser value to `~/.summer/creator-token`; never replaces the auth token |
 | Skill files | < 50 KB | bundled in the npm package | no extra network call |
 | Generated assets (3D / image / audio / video) | varies | only on explicit `summer_generate_*` calls | Summer Engine Studio |
 | URL imports | varies | only on explicit `summer_import_from_url` calls | the URL you provide |
@@ -255,7 +261,10 @@ Two pieces, plus the glue.
 
 Skills don't list steps. They encode the **order of operations**: diagnose before editing, scope before building, ask before guessing. [Agent Skills](https://agentskills.io) format, so any conformant tool picks them up.
 
-**MCP bridge.** The `summer-engine` MCP server gives the agent 56 tools that talk to your local engine on `localhost:6550`:
+**MCP bridge.** The `summer-engine` MCP server gives the agent 62 tools. Local
+project tools connect to your engine on `localhost:6550`; cloud and creator
+tools use their documented remote or local contracts without requiring the
+editor:
 
 | | |
 |---|---|
@@ -267,6 +276,7 @@ Skills don't list steps. They encode the **order of operations**: diagnose befor
 | Project | `summer_get_project_context`, `summer_open_main_scene`, `summer_project_setting`, `summer_input_map_bind` |
 | Files | `summer_read_file`, `summer_write_file`, `summer_replace_text` — identity-bound, create-only or sha256-guarded mutations |
 | Assets | `summer_search_assets`, `summer_import_asset`, `summer_import_from_url`, `summer_generate_image`, `summer_generate_3d`, `summer_generate_audio`, `summer_generate_video` |
+| Creator | `summer_creator_publish`, `summer_creator_releases`, `summer_creator_logs`, `summer_creator_config` — confirmed immutable publishing, real release history, explicit unsupported logs, and non-secret shared configuration |
 
 Git, shell, and grep remain host-native. Project file reads and writes use Summer's identity-bound tools so compatible engine builds can reject wrong-project and stale-content mutations. A host agent can still bypass these safeguards with its own file tools; the package cannot technically intercept that external process.
 
@@ -339,7 +349,9 @@ The skill bundle replaces "agent flailing through tutorials" with measurable cra
 
 **Skill authoring**: `skill-create`, `skill-improve`, `skill-test`
 
-C# is supported by the engine. A `summer:csharp-patterns` skill is on the roadmap; for now write C# from Godot 4.5 docs.
+C# is supported by the engine. A `summer:csharp-patterns` skill is on the
+roadmap; for version-sensitive APIs, use the bundled
+[Summer Engine compatibility reference](references/godot-version.md).
 
 Full list of shipping skills: the `skills:` array in [`.claude-plugin/plugin.json`](./.claude-plugin/plugin.json).
 
@@ -477,8 +489,13 @@ npx -y summer-engine@latest doctor
 | Command | What it does |
 |---|---|
 | `summer install` | Download Summer Engine. Prints URL and size first. |
-| `summer login` | Browser-based sign-in. |
+| `summer login` | Browser-based core Summer sign-in. |
+| `summer login --creator` | Open Summercraft token settings and securely connect a separate publish-scoped creator token. |
 | `summer logout` | Clear auth tokens. |
+| `summer config [get\|set\|unset]` | Read or update shared non-secret configuration. |
+| `summer publish [project] --artifact <game.pck> --version <value> [--confirm]` | Review an exact immutable artifact target, then publish it through prepare → write-once upload → finalize. |
+| `summer releases [--cursor <value>]` | List real creator-owned release history. |
+| `summer logs` | Fail closed until the platform has a durable, authorized runtime-log source. |
 | `summer status` | Engine state, port, auth. |
 | `summer doctor` | Diagnose Node, login, engine, project memory, MCP. |
 | `summer plan <goal>` | Route a game-building goal into skills, MCP tools, gates, and verification. |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -10,12 +10,15 @@ If you're an AI agent or developer with zero context, read this first.
 
 ## What This Is
 
-**Summer Engine** is the AI game engine, built on the Godot team's work and customized so AI agents and humans can collaborate on games. It's a proprietary binary you download via `summer install` or from [summerengine.com/download](https://summerengine.com/download).
+**Summer Engine** is the proprietary AI game engine binary users download via
+`summer install` or from
+[summerengine.com/download](https://summerengine.com/download). Users make
+Summer games with the Summer SDK and GDScript.
 
 **Summer** (this repo) is the **open-source agent layer** for it. Three things in one Node.js package:
 
 1. **CLI tool**: lets users install, manage, and launch Summer Engine from their terminal
-2. **MCP server**: gives AI coding agents 56 tools, including identity-bound project files, scene manipulation, play/stop, diagnostics, and asset import/generation
+2. **MCP server**: gives AI coding agents 62 tools, including identity-bound project files, scene manipulation, play/stop, diagnostics, asset import/generation, cloud workflows, and creator publishing
 3. **Skills bundle**: the current SKILL.md playbooks that auto-trigger when the agent sees the right natural-language signal
 
 Plus lifecycle hooks, plugin manifests, and setup targets that wire all of the above into Claude Code, Cursor, Codex, Gemini, OpenCode, GitHub Copilot CLI, GitHub Copilot in VS Code, Cline, Roo Code, Factory Droid, and Devin Desktop (formerly Windsurf).
@@ -144,6 +147,10 @@ tools/summer-cli/
     │   ├── install.ts         # summer install - downloads engine
     │   ├── login.ts           # summer login - browser OAuth
     │   ├── logout.ts          # summer logout - clears tokens
+    │   ├── config.ts          # summer config - shared non-secret config
+    │   ├── publish.ts         # summer publish - confirmed creator release
+    │   ├── releases.ts        # summer releases - creator history
+    │   ├── logs.ts            # summer logs - explicit durable-log boundary
     │   ├── status.ts          # summer status - engine diagnostics
     │   ├── run.ts             # summer run [path] - launches engine
     │   ├── open.ts            # summer open <path> - opens project
@@ -164,7 +171,10 @@ tools/summer-cli/
     │
     └── lib/                   # Shared utilities
         ├── api-client.ts      # HTTP client for engine's local API
-        ├── auth.ts            # Read/write ~/.summer/auth-token
+        ├── store.ts           # Hardened shared ~/.summer store
+        ├── auth.ts            # Core-compatible identity + token metadata
+        ├── config.ts          # Typed non-secret configuration
+        ├── creator.ts         # Versioned creator publish/history client
         ├── engine.ts          # Engine detection, health check, port reading
         └── project-memory.ts  # Lightweight .summer memory summary
 ```
@@ -175,12 +185,25 @@ tools/summer-cli/
 
 The MCP server does NOT require the engine to be running at startup. It starts immediately, registers all tools, and connects to the engine lazily on first tool call. If the engine stops mid-session, the next tool call retries. This is handled by `with-engine.ts`.
 
-### Auth Token Flow
+### Shared `~/.summer/` Store
 
-Two separate tokens in `~/.summer/`:
+The CLI, existing MCP, exporters, and desktop engine share one secured
+`~/.summer/` directory. Existing filenames are preserved because other Summer
+Engine consumers already read them:
+
 - `api-token` - written by the engine's `LocalApiServer` on startup. Random per-session. The MCP server reads this to authenticate with the engine. **Only valid while engine is running.**
-- `auth-token` - written by `summer login`. Long-lived JWT for user identity. Used for analytics/tracking. **Persists across sessions.**
-- `user.json` - written by the engine when user signs in via WebView. Contains `{id, email}`.
+- `auth-token` - core Summer CLI JWT written by `summer login`.
+- `cloud-token` - separate Summer Cloud credential.
+- `creator-token` - separate Summercraft `sc_` credential connected by
+  `summer login --creator`; it never replaces `auth-token`.
+- `user.json` - validated `{id, email, name?}` core identity.
+- `credential-metadata.json` - non-secret audience, scope, type, and expiry.
+- `config.json` - typed, non-secret shared configuration.
+- `creator-audit.jsonl` - secret-free local creator publish receipts.
+
+Normal users need no new environment variables. See
+[GATE_E3_CREATOR_CLI.md](GATE_E3_CREATOR_CLI.md) for the exact API,
+confirmation, credential, and residual activation contract.
 
 ### Template System (`commands/create.ts`)
 

--- a/docs/GATE_E3_CREATOR_CLI.md
+++ b/docs/GATE_E3_CREATOR_CLI.md
@@ -1,0 +1,125 @@
+# Gate E3: Creator CLI and MCP
+
+Status: publish and release history are implemented against
+`summer.creator.v1`; runtime logs remain explicitly unsupported.
+
+Last audited: 2026-07-30 against Summercraft main
+`76b893838be0743912efa2d35484966a5ee0156d`.
+
+## What works
+
+- `POST /api/creator/v1/publish` supports `prepare` and `finalize`.
+- Publish delegates to the existing immutable R2 upload, checksum, ownership,
+  rate-limit, review, and release-record plane.
+- `GET /api/creator/v1/releases` returns creator-owned cursor-paginated
+  history.
+- The server independently verifies the existing exact `publish` scope and
+  project ownership on every request.
+- Creator runtime logs are not fabricated. No route is enabled because the
+  platform has no durable log owner, retention policy, redaction policy, or
+  authorized query store.
+
+The core Summer browser-login JWT remains `type=cli`, `aud=summer-cli`.
+It is not a Summercraft creator token and is never overwritten or repurposed.
+
+## Local credential and config contract
+
+All surfaces share the secured `~/.summer/` directory:
+
+| File | Purpose |
+|---|---|
+| `auth-token` | Core Summer CLI JWT. Existing filename preserved for Summer Engine consumers. |
+| `cloud-token` | Existing separate Summer Cloud credential. |
+| `creator-token` | Separate Summercraft `sc_` token with exact `publish` scope. |
+| `user.json` | Core identity matched against the CLI JWT subject before persistence. |
+| `credential-metadata.json` | Non-secret audience, scope, type, and expiry metadata. |
+| `config.json` | Versioned non-secret CLI/MCP configuration. |
+| `creator-audit.jsonl` | Secret-free local creator publish attempts and outcomes. |
+
+On POSIX, the directory is `0700` and files are `0600`. Writes use
+same-directory temporary files and atomic rename. Symlinked credential files
+are refused. Logout clears identity credentials, including `creator-token`,
+but does not rotate or rename any platform secret.
+
+Normal users need no new environment variables. Defaults are:
+
+- Summer gateway: `https://www.summerengine.com`
+- Summercraft creator API: `https://summercraft.ai`
+
+Supported non-secret config keys:
+
+- `gateway.url`
+- `creator.apiUrl`
+- `creator.projectId`
+- `creator.channel`
+
+Remote origins require HTTPS; HTTP is accepted only for loopback development.
+`creator.channel` currently supports only `production`, because the v1 backend
+does not pretend to provide preview-channel semantics.
+
+## One-time creator setup
+
+1. Keep using `summer login` for core Summer identity.
+2. Run `summer login --creator`.
+3. The CLI opens Summercraft creator token settings.
+4. Mint a token with the exact `publish` scope and paste the one-time `sc_`
+   value into the hidden terminal prompt.
+5. Configure the Summer game UUID:
+   `summer config set creator.projectId <uuid>`.
+
+The additive `cApiTokens` catalog objects already exist and are recorded in
+shared Supabase migration history as version `20260730073920`. The client
+treats server token refusal as authoritative and never falls back to an
+unrelated credential.
+
+## Publishing
+
+The CLI never guesses an export layout or silently builds an artifact:
+
+```text
+summer publish . \
+  --artifact /absolute/path/to/game.pck \
+  --version 1.0.0 \
+  --notes "First release"
+```
+
+The first call omits `--confirm`. It computes the real size and SHA-256,
+records the target locally, and returns the exact project, version, digest,
+size, and path without making a network request.
+
+Only after the user approves that exact target should the command be repeated
+with `--confirm`. The client then:
+
+1. recomputes artifact digest and size;
+2. sends `operation=prepare` with an exact repeated confirmation object;
+3. validates the versioned response, HTTPS or loopback upload URL, expected
+   content type, and `if-none-match: *`;
+4. streams the `.pck` directly to the presigned URL without exposing the
+   creator token to object storage;
+5. sends `operation=finalize` with the same exact target;
+6. accepts success only when the server echoes the project, version, digest,
+   size, valid release ID, and `pending_review` state;
+7. records a secret-free success or failure in `creator-audit.jsonl`.
+
+The same implementation backs `summer_creator_publish`. Agents must call it
+with `confirm=false`, present the exact target, obtain approval, and only then
+call it with `confirm=true`.
+
+`summer releases` and `summer_creator_releases` return real history. The
+opaque `nextCursor` must be reused unchanged. `summer logs` and
+`summer_creator_logs` fail closed until a durable log plane exists.
+
+## Remaining activation work
+
+| Residual | Owner / next action |
+|---|---|
+| No real disposable-token artifact witness from the canonical npm client | Operator: after merge and release, mint a disposable scoped token, publish a non-production witness artifact through review, verify history, then revoke it. |
+| No npm release containing this client | CLI release owner: version and publish only after this PR is merged and reviewed. This change does not publish npm. |
+| No durable runtime-log source | Runtime platform: define ingestion, retention, redaction, authorization, and query ownership first. |
+| No automatic export handoff | Export pipeline: produce an immutable `.pck` explicitly; the CLI must not guess or build without approval. |
+| Finalize response can be lost after server success | Operator: query `summer releases` before retrying; immutable version/digest prevents silent replacement. |
+| Broader public-language corpus still contains technical upstream references | Docs owner: audit remaining references by context, preserving legal/history and technical node/file-format facts while keeping product language Summer-first. |
+
+Focused tests use temporary stores, artifact files, and mock HTTP/object-store
+responses. They perform no production requests, secret changes, migrations,
+deployments, npm publishing, or key rotation.

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -10,7 +10,8 @@ Three things, plus glue.
 
 **Skills (60).** Markdown files. Each one is a discipline guide — debug, brainstorm, FPS controller, multiplayer, art direction, ship. They auto-fire on natural language. No slash command needed.
 
-**MCP server.** Thirty-seven tools that talk to a running Summer Engine on `localhost:6550`. Scene mutation, asset import, runtime control, diagnostics, generation. Your agent calls them; the engine moves.
+**MCP server.** Sixty-two tools spanning local Summer Engine control, cloud
+workflows, and creator publishing. Your agent calls them; the engine moves.
 
 **CLI.** Install the engine, log in, scaffold projects, run them, run doctor. The terminal side.
 
@@ -78,10 +79,13 @@ For live scene hierarchy/inspector work, prefer scene tools. Guarded `.tscn` tex
 
 ## Scripting
 
-Summer Engine is compatible with Godot 4.5. Pick one:
+You are writing a Summer game with the Summer SDK. Pick one:
 
 - **GDScript** (`.gd`) — default. Best supported by Summer skills (see `summer:gdscript-patterns`).
-- **C#** (`.cs`) — fully supported by the engine. No `summer:csharp-patterns` skill yet — write from Godot 4.5 C# docs. Different lifecycle, different signal API, different export attributes. Don't blindly translate GDScript idioms.
+- **C#** (`.cs`) — fully supported by the engine. No `summer:csharp-patterns`
+  skill exists yet; use the bundled compatibility reference for
+  version-sensitive APIs. Different lifecycle, signal, and export-attribute
+  patterns mean GDScript idioms should not be translated blindly.
 
 Scenes are always `.tscn`/`.scn`. Resources are always `.tres`/`.res`.
 

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -1,6 +1,7 @@
 # Skills
 
-Summer skills teach AI agents how to build games in Summer Engine, the AI-native game engine compatible with Godot 4.5 (GDScript and `.tscn` scenes). Two kinds:
+Summer skills teach AI agents how to build Summer games with the Summer SDK.
+GDScript and `.tscn` scenes are first-class. Two kinds:
 
 ## Workflow skills (slash commands)
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "files": [
     "dist/",
     "skills/",
+    "references/",
     "commands/",
     "hooks/",
     "assets/",

--- a/references/godot-version.md
+++ b/references/godot-version.md
@@ -1,32 +1,51 @@
-# Godot / Summer Engine Version Reference
+# Summer Engine Technical Compatibility Reference
 
-> Read this **before** writing any code, especially shaders or rendering code. Godot's API is moving; the LLM cutoff date matters per domain.
+> This is an implementation note for version-sensitive engine work. Product
+> language should say **Summer Engine**, **Summer SDK**, and **Summer game**.
 
-## Engine fork base
+## Current and planned upstream base
 
-Summer Engine is a fork of **Godot 4.5** (stable). All skills assume Godot 4.x APIs.
+- Current Summer Engine base: **4.6.1**
+- Planned next base: **4.7.1**
+- Policy: Summer Engine follows upstream Godot continuously. Do not pin public
+  onboarding, skills, or product descriptions to one upstream version.
 
-## LLM training cutoff vs. Godot release dates
+Summer Engine is its own product and SDK. It inherits parts of its scene,
+resource, scripting, and rendering API from the upstream Godot codebase, while
+adding Summer-specific editor, agent, platform, and runtime capabilities.
+Use the live Summer Engine build and this compatibility reference as the
+authority; do not describe a creator's project as a Godot game.
 
-| Domain | Godot 4.x churn | Action |
+## Version-sensitive areas
+
+| Domain | Expected churn | Action |
 |---|---|---|
-| Scripting (GDScript core) | low | Trust your training. Spot-check signatures only when something feels off. |
-| Scene / node tree APIs | low | Trust your training. |
-| Renderer (`RenderingServer`, `Compositor`) | high in 4.4 / 4.5 | Verify before writing. Check `MovieMaker`, `Compositor` effects, `RenderSceneBuffers` — these renamed/added recently. |
-| Shaders (`canvas_item`, `spatial`, `compute`) | medium | Built-in functions stable, but `hint_*` flags shifted. Verify `hint_screen_texture` / `hint_depth_texture` syntax. |
-| Animation (`AnimationTree`, `AnimationMixer`) | high (4.0 → 4.3 rename) | Use `AnimationMixer` for new code, not deprecated `AnimationPlayer`-as-mixer. |
-| Multiplayer (`MultiplayerAPI`) | medium | High-level API stable. `SceneReplicationConfig` settled in 4.0+. |
-| Editor / EditorPlugin | medium | Spot-check. |
-| `Tween` / `SceneTreeTween` | low | Stable since 4.0. |
+| GDScript core | low | Prefer current Summer SDK patterns; spot-check signatures when uncertain. |
+| Scene and node APIs | low | Prefer Summer MCP inspection over guessing. |
+| Renderer (`RenderingServer`, `Compositor`) | high | Verify against the installed Summer Engine build before writing. |
+| Shaders (`canvas_item`, `spatial`, `compute`) | medium | Verify built-ins and `hint_*` syntax against the installed build. |
+| Animation (`AnimationTree`, `AnimationMixer`) | medium | Prefer current, non-deprecated Summer Engine APIs. |
+| Multiplayer (`MultiplayerAPI`) | medium | Verify transport and replication behavior against Summer Engine. |
+| Editor / `EditorPlugin` | medium | Treat as Engine-contributor work and spot-check the current source. |
+| `Tween` / `SceneTreeTween` | low | Use current Summer SDK conventions. |
 
-## Summer-specific deltas from vanilla Godot
+## Summer-specific surfaces
 
-- Local API server runs on `localhost:6550` (set per machine via `~/.summer/api-token`).
-- Engine ships a webview module in `modules/1summer_engine/` — do not assume vanilla Godot for editor UI patches.
-- Project root contains `.summer/` for project memory; do not delete it.
+- The local Summer API server runs on `localhost:6550` and authenticates with
+  the per-machine `~/.summer/api-token`.
+- Summer editor integration lives in Summer-specific engine modules; do not
+  assume an upstream editor build for editor or platform patches.
+- Project memory lives in the project-root `.summer/` directory.
+- Creator publishing uses the versioned `summer.creator.v1` contract and a
+  separate Summercraft `creator-token`; it never replaces the core
+  `auth-token`.
 
 ## When in doubt
 
-1. Use Summer MCP tools (`summer_inspect_node`, `summer_inspect_resource`) to read live editor state instead of guessing.
-2. Use `summer_get_diagnostics` after every scene change.
-3. Check `references/mcp-tools-reference.md` for the canonical tool list.
+1. Use Summer MCP tools such as `summer_inspect_node` and
+   `summer_inspect_resource` to read live engine state.
+2. Run `summer_get_diagnostics` after scene changes.
+3. Check `references/mcp-tools-reference.md` for the canonical Summer tool
+   surface.
+4. For Engine-fork work, inspect the current source base rather than relying
+   on a fixed-version tutorial.

--- a/references/mcp-tools-reference.md
+++ b/references/mcp-tools-reference.md
@@ -17,7 +17,7 @@
 
 **Rule of thumb:** project reads/writes go through Summer; live hierarchy/inspector changes use scene tools; process-level work remains with the host.
 
-## Tool surface (56 tools)
+## Tool surface (62 tools)
 
 ### Project files (3)
 
@@ -139,6 +139,15 @@
 | `summer_cloud_restore` | Restore a retained cloud version, or a local pre-sync checkpoint. |
 | `summer_cloud_checkpoints` | List local pre-sync checkpoints. |
 | `summer_cloud_conflicts` | List conflict sets, or restore a preserved conflict file. |
+
+### Creator platform (4)
+
+| Tool | Use |
+|---|---|
+| `summer_creator_publish` | Compute the exact `.pck` digest and size, require user confirmation, then run versioned prepare → write-once upload → finalize. |
+| `summer_creator_releases` | List real creator-owned releases from `summer.creator.v1`, preserving opaque pagination cursors. |
+| `summer_creator_logs` | Fail closed until a durable, authorized, redacted runtime-log source exists. |
+| `summer_creator_config` | Read or confirm changes to shared non-secret configuration. It never accepts or returns tokens. |
 
 ## Common pattern
 

--- a/skills/3d-assets/character-model/SKILL.md
+++ b/skills/3d-assets/character-model/SKILL.md
@@ -154,11 +154,11 @@ summer_import_asset_by_id(
 
 ### 5. ⚠️ Restart the editor
 
-**Known Godot 4.5 gotcha:** after importing a rigged `.glb`, the `Skeleton3D` node appears stale in the scene dock — bones are missing, `skeleton.get_bone_count()` returns 0, and `AnimationPlayer` libraries fail to bind. The fix:
+**Known Summer Engine gotcha:** after importing a rigged `.glb`, the `Skeleton3D` node appears stale in the scene dock — bones are missing, `skeleton.get_bone_count()` returns 0, and `AnimationPlayer` libraries fail to bind. The fix:
 
 > The rigged mesh is imported. Please restart the Summer Engine editor (close and reopen) so the Skeleton3D rebuilds correctly. Without the restart, animations will fail to bind.
 
-There is no programmatic workaround as of Godot 4.5.x. Tell the user, wait, then continue.
+There is no programmatic workaround as of the current Summer Engine base. Tell the user, wait, then continue.
 
 ### 6. Wire as CharacterBody3D or Node3D — pick the right parent
 

--- a/skills/3d-assets/vehicle-model/SKILL.md
+++ b/skills/3d-assets/vehicle-model/SKILL.md
@@ -135,7 +135,7 @@ This re-textures the existing mesh with sharper detail — panel lines, decals, 
 
 | Use case | Parent type | Notes |
 |---|---|---|
-| Player-driven (car, bike, hover) | `VehicleBody3D` (Godot 4.5 wheeled) or `RigidBody3D` (free physics) | Add `VehicleWheel3D` children for wheeled vehicles |
+| Player-driven (car, bike, hover) | `VehicleBody3D` (Summer Engine wheeled) or `RigidBody3D` (free physics) | Add `VehicleWheel3D` children for wheeled vehicles |
 | Player-driven (spaceship, mech) | `RigidBody3D` or `CharacterBody3D` | Custom thrust / walk code, see `summer:character-controllers` |
 | Background scenery (parked, flyby) | `MeshInstance3D` under a `Node3D` | No physics, no collision needed for distant traffic |
 | Background traffic (moving but not interactive) | `Node3D` + `AnimationPlayer` driving the position | Cheap, no physics overhead |

--- a/skills/ai-and-npcs/design-npc/SKILL.md
+++ b/skills/ai-and-npcs/design-npc/SKILL.md
@@ -472,7 +472,7 @@ For a fully-rigged enemy with anim controller + loot drop:
 ## See also
 
 - `references/mcp-tools-reference.md` — full MCP tool list
-- `references/godot-version.md` — Godot 4.5 API notes
+- `references/godot-version.md` — Summer Engine API notes
 - `references/collaborative-protocol.md` — "May I write" pattern
 - `references/gd-style.md` — typed GDScript conventions
 - `ai-and-npcs/state-machine-npc/SKILL.md` — FSM pattern deep dive

--- a/skills/animation/animation-tree/SKILL.md
+++ b/skills/animation/animation-tree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: animation-tree
-description: Use when the user has clips on a character and needs them to play in response to gameplay — idle/walk/run blend, attacks that interrupt locomotion, hit reactions that override everything. Designs and wires AnimationTree state machines and blend trees in Godot 4.5. Trigger on "AnimationTree", "state machine", "blend tree", "transition", "play animation when", "character keeps T-posing", "wire animations".
+description: Use when the user has clips on a character and needs them to play in response to gameplay — idle/walk/run blend, attacks that interrupt locomotion, hit reactions that override everything. Designs and wires AnimationTree state machines and blend trees in Summer Engine. Trigger on "AnimationTree", "state machine", "blend tree", "transition", "play animation when", "character keeps T-posing", "wire animations".
 license: MIT
 compatibility: [Cursor, Claude Code, Windsurf, Codex]
 category: animation
@@ -13,7 +13,7 @@ paths: ["**/*.gd", "**/*.tscn", "**/*.tres"]
 
 Generation gives you clips. The AnimationTree gives the character life. This skill is **not generative** — no FAL, no MCP AI calls. It composes existing clips on an `AnimationPlayer` into an `AnimationTree` with a `StateMachine` for distinct states (idle / attack / hit / dead) and `BlendSpace` nodes for continuous parameters (walk-run blend by speed). Done right, the character moves like a shipped game; done wrong, you get T-poses, snapping, or animations that "eat" each other.
 
-The canonical Godot 4.5 stack:
+The canonical Summer Engine stack:
 
 ```
 Character (CharacterBody3D)
@@ -190,7 +190,7 @@ Then `summer_play` and watch — the goblin should idle in place, blend up to wa
 
 ## Reference card
 
-### Parameter paths cheat-sheet (Godot 4.5)
+### Parameter paths cheat-sheet (Summer Engine)
 
 | Goal | Path |
 |---|---|
@@ -245,7 +245,7 @@ Then `summer_play` and watch — the goblin should idle in place, blend up to wa
 
 ## Fallback (no MCP)
 
-Open the scene in Godot 4.5 editor, add `AnimationTree` node, set `Anim Player` to the AnimationPlayer, set `Active = on`, double-click `Tree Root` and edit visually. Drag `AnimationNodeStateMachine` as the root, drop nodes inside, draw transitions by Shift-dragging. Save the scene. The visual editor produces the same `.tres` — slower but discoverable.
+Open the scene in Summer Engine editor, add `AnimationTree` node, set `Anim Player` to the AnimationPlayer, set `Active = on`, double-click `Tree Root` and edit visually. Drag `AnimationNodeStateMachine` as the root, drop nodes inside, draw transitions by Shift-dragging. Save the scene. The visual editor produces the same `.tres` — slower but discoverable.
 
 ## Handoff
 

--- a/skills/animation/facial-and-lipsync/SKILL.md
+++ b/skills/animation/facial-and-lipsync/SKILL.md
@@ -263,7 +263,7 @@ If the user has a CMUDict-style phoneme list and wants to map manually, this is 
 
 If Rhubarb won't install on the user's platform, run a Whisper-phoneme model on Replicate (e.g., `cjwbw/whisper-phoneme`) or `aeneas-align` for forced alignment. Download the JSON, swap the bake function for one that consumes ARPAbet phonemes (table in Reference card). Same end result — replayable BlendShape Animation resource.
 
-For projects that can't use any cloud or third-party tool, Godot 4.5's `AudioStreamGenerator` with hand-rolled vowel/consonant detection from RMS + zero-crossings gives ~50% accuracy — enough for a stylized character but not photoreal.
+For projects that can't use any cloud or third-party tool, Summer Engine's `AudioStreamGenerator` with hand-rolled vowel/consonant detection from RMS + zero-crossings gives ~50% accuracy — enough for a stylized character but not photoreal.
 
 ## Handoff
 

--- a/skills/animation/generate-motion/SKILL.md
+++ b/skills/animation/generate-motion/SKILL.md
@@ -113,7 +113,7 @@ The full list is ~70 names. If the user asks for something not on the top-30, tr
 ### Pitfalls
 
 - **`motionName` typos silently match nothing.** `"run_fast"` is not on the list — the call returns an error. Always check the curated list first. Use exact strings from the list above.
-- **Locomotion clips have a forward bias.** Meshy's `run` translates the root forward by ~5m. If you're driving root motion in code, set `root_motion_track` correctly or strip the translation in an AnimationPlayer Edit. See the Godot 4.5 root motion docs.
+- **Locomotion clips have a forward bias.** Meshy's `run` translates the root forward by ~5m. If you're driving root motion in code, set `root_motion_track` correctly or strip the translation in an AnimationPlayer Edit. See the Summer Engine root motion docs.
 - **Rig pose mismatch.** If your rig was rigged with a non-T-pose reference image, the limbs may bend wrong. Re-rig from a T-pose mannequin (see `summer:asset-pipeline/asset-strategy`) before re-generating.
 - **Rig still preparing.** New rigs need ~3 minutes after the rig job completes before the animation library is ready. The MCP route returns 425 "animations_preparing" if you call too early. Wait and retry.
 

--- a/skills/animation/procedural-animation/SKILL.md
+++ b/skills/animation/procedural-animation/SKILL.md
@@ -11,9 +11,9 @@ paths: ["**/*.gd", "**/*.tscn", "**/*.tres"]
 
 # Procedural Animation — Bones Driven by Code
 
-Generated clips give you 80% of a character. The remaining 20% — the eye contact when an NPC speaks, feet that plant on slopes, hands that wrap a sword grip, the lean into a sprint, the recoil from a hit on the left shoulder — is procedural. In Godot 4.5 this is done via the `SkeletonModifier3D` family attached to the `Skeleton3D`, plus tween-driven additive blend layers on the `AnimationTree`. None of it is generative; this skill is a recipe set.
+Generated clips give you 80% of a character. The remaining 20% — the eye contact when an NPC speaks, feet that plant on slopes, hands that wrap a sword grip, the lean into a sprint, the recoil from a hit on the left shoulder — is procedural. In Summer Engine this is done via the `SkeletonModifier3D` family attached to the `Skeleton3D`, plus tween-driven additive blend layers on the `AnimationTree`. None of it is generative; this skill is a recipe set.
 
-Honest limit: Godot 4.5's IK is good enough for look-at, foot-snap, and simple two-bone arm/leg chains. It is NOT good enough for full-body IK with weight redistribution (a la UE5 Control Rig). For combat-grappling or contact-heavy interactions, hand-author the contact frame and accept some clipping.
+Honest limit: Summer Engine's IK is good enough for look-at, foot-snap, and simple two-bone arm/leg chains. It is NOT good enough for full-body IK with weight redistribution (a la UE5 Control Rig). For combat-grappling or contact-heavy interactions, hand-author the contact frame and accept some clipping.
 
 ## When to use this skill
 
@@ -89,7 +89,7 @@ Multiple `LookAtModifier3D` nodes on the same chain — one for `Spine1` (limit 
 
 ### A3 — Foot IK (slopes & uneven terrain)
 
-The clip has the foot at Y=0; on a slope the ground is at Y=0.15. Without IK, foot floats. Use `SkeletonIK3D` (Godot 4.5 legacy IK still works for two-bone chains; the new chain modifier is preferred for production):
+The clip has the foot at Y=0; on a slope the ground is at Y=0.15. Without IK, foot floats. Use `SkeletonIK3D` (Summer Engine legacy IK still works for two-bone chains; the new chain modifier is preferred for production):
 
 ```gdscript
 @onready var skel: Skeleton3D = $Skeleton3D
@@ -231,4 +231,4 @@ Add modifiers in the Godot editor under Skeleton3D, set bone names from the insp
 
 - `references/gd-style.md` — typed GDScript conventions in the snippets.
 - `references/mcp-tools-reference.md` — `summer_set_prop` enum-int conventions for axis settings.
-- Godot 4.5 docs: `SkeletonModifier3D`, `LookAtModifier3D`, `SkeletonIK3D`, `PhysicalBoneSimulator3D`.
+- Summer Engine docs: `SkeletonModifier3D`, `LookAtModifier3D`, `SkeletonIK3D`, `PhysicalBoneSimulator3D`.

--- a/skills/animation/retarget/SKILL.md
+++ b/skills/animation/retarget/SKILL.md
@@ -156,7 +156,7 @@ The break-even is two characters. Past that, retarget is always cheaper.
 
 ## Fallback (no MCP)
 
-Open the source `.glb` in Blender, export the animation, then in Godot 4.5 use the BoneMap-based humanoid retargeting workflow (Project → Tools → Bone Map). Set both source and target as humanoid profile, configure the bone mapping if names differ, save the retargeted clip into the target's `AnimationLibrary`. ~5 minutes per clip vs ~10 seconds via MCP. Documented in the Godot 4.5 character animation docs.
+Open the source `.glb` in Blender, export the animation, then in Summer Engine use the BoneMap-based humanoid retargeting workflow (Project → Tools → Bone Map). Set both source and target as humanoid profile, configure the bone mapping if names differ, save the retargeted clip into the target's `AnimationLibrary`. ~5 minutes per clip vs ~10 seconds via MCP. Documented in the Summer Engine character animation docs.
 
 ## Handoff
 

--- a/skills/audio/adaptive-music/SKILL.md
+++ b/skills/audio/adaptive-music/SKILL.md
@@ -323,4 +323,4 @@ Print the bus layout, the node tree, and the GDScript. User constructs in the Go
 - `audio/audio-direction` — defines the dynamic music plan and bus layout
 - `audio/music-track` — generates the stems
 - `audio/voice-line` — the voice bus that triggers ducking
-- `references/godot-version.md` — Godot 4.5 AudioServer and Tween API
+- `references/godot-version.md` — Summer Engine AudioServer and Tween API

--- a/skills/audio/audio-direction/SKILL.md
+++ b/skills/audio/audio-direction/SKILL.md
@@ -248,7 +248,7 @@ No template — this is a workflow that produces the bible the rest of the proje
 ## See also
 
 - `references/collaborative-protocol.md`
-- `references/godot-version.md` — Godot 4.5 audio API notes
+- `references/godot-version.md` — Summer Engine audio API notes
 - `references/mcp-tools-reference.md`
 - `scene-and-project/brainstorm-game/SKILL.md` — produces the brief that anchors the bible
 - `rendering-and-lighting/art-direction/SKILL.md` — the visual counterpart; audio must rhyme with it

--- a/skills/audio/sound-effect/SKILL.md
+++ b/skills/audio/sound-effect/SKILL.md
@@ -234,4 +234,4 @@ After the SFX is wired:
 - `audio/music-track` — music
 - `audio/voice-line` — TTS
 - `references/mcp-tools-reference.md`
-- `references/godot-version.md` — Godot 4.5 audio nodes
+- `references/godot-version.md` — Summer Engine audio nodes

--- a/skills/deployment/export-and-ship/SKILL.md
+++ b/skills/deployment/export-and-ship/SKILL.md
@@ -15,6 +15,13 @@ paths: ["**/*.gd", "**/*.tscn", "project.godot", "export_presets.cfg", "**/*.png
 
 Shipping is a checklist, not a creative act. This skill walks the platform-specific asset and config requirements, runs a pre-flight check against the project, and produces a release build only after every blocker is green. Better to fail at this step than fail submission.
 
+Availability boundary: the public Summer Engine currently ships on macOS
+Apple silicon and Windows. Steam, browser, mobile, Linux, and other store
+distribution lanes are planned targets. The checklists below may prepare a
+project for those targets, but must not claim that Summer's integrated export
+or submission path is shipping until the installed engine, templates,
+toolchain, and current platform documentation prove it.
+
 **Core principle:** every platform has a list. Read the list, satisfy the list, ship.
 
 ## Steps
@@ -289,7 +296,7 @@ No template — this is a workflow. Each project's export config and store asset
 ## See also
 
 - `references/mcp-tools-reference.md` — full MCP tool list
-- `references/godot-version.md` — Godot 4.5 export-template versioning
+- `references/godot-version.md` — Summer Engine export-template versioning
 - `references/collaborative-protocol.md` — "May I write" pattern
 - `deployment/export-presets/SKILL.md` — preset config deep dive
 - `deployment/web-html5-export/SKILL.md` — HTML5-specific traps

--- a/skills/gameplay-mechanics/design-mechanic/SKILL.md
+++ b/skills/gameplay-mechanics/design-mechanic/SKILL.md
@@ -257,7 +257,7 @@ This skill is a workflow that designs and scaffolds — the templates are runnab
 - `references/collaborative-protocol.md`
 - `references/mcp-tools-reference.md`
 - `references/gd-style.md` — GDScript conventions
-- `references/godot-version.md` — Godot 4.5 API notes
+- `references/godot-version.md` — Summer Engine API notes
 - `scene-and-project/brainstorm-game/SKILL.md` — produces `.summer/GameSoul.md` this skill reads
 - `level-design/design-level/SKILL.md` — design the levels that exercise the mechanic
 - `character-controllers/fps-controller/SKILL.md` — FPS movement scaffolding

--- a/skills/level-design/design-level/SKILL.md
+++ b/skills/level-design/design-level/SKILL.md
@@ -258,7 +258,7 @@ The skeleton this skill produces is meant to be filled in via `/summer:design-me
 
 - `references/collaborative-protocol.md`
 - `references/mcp-tools-reference.md`
-- `references/godot-version.md` — Godot 4.5 API notes
+- `references/godot-version.md` — Summer Engine API notes
 - `scene-and-project/brainstorm-game/SKILL.md` — produces `.summer/GameSoul.md`
 - `gameplay-mechanics/design-mechanic/SKILL.md` — designs the verbs the level exercises
 - `ai-and-npcs/design-npc/SKILL.md` — designs the enemies the encounters reference

--- a/skills/multiplayer-and-networking/host-authoritative-state/SKILL.md
+++ b/skills/multiplayer-and-networking/host-authoritative-state/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: host-authoritative-state
-description: Use when designing the state layer of a multiplayer Godot game — deciding what's host-owned, how clients request changes, how the host validates and broadcasts. Pairs with `/peer-to-peer-multiplayer`. Trigger on "host authority", "authoritative state", "state ownership", "MP cheating", "client validation", "RPC patterns".
+description: Use when designing the state layer of a multiplayer Summer game — deciding what's host-owned, how clients request changes, how the host validates and broadcasts. Pairs with `/peer-to-peer-multiplayer`. Trigger on "host authority", "authoritative state", "state ownership", "MP cheating", "client validation", "RPC patterns".
 license: MIT
 compatibility: [Cursor, Claude Code, Windsurf, Codex]
 category: multiplayer-and-networking
@@ -327,6 +327,6 @@ After each Manager file lands, call `summer_get_script_errors` to confirm clean 
 
 - [`peer-to-peer-multiplayer`](../peer-to-peer-multiplayer/SKILL.md) — the four-layer architecture overview. Read this first if you haven't.
 - [`setup-multiplayer`](../setup-multiplayer/SKILL.md) — lighter intro that just gets a session running. Use that one if the user just wants two players to see each other.
-- [`references/godot-version.md`](../../references/godot-version.md) — Godot 4.5 multiplayer API stability notes.
+- [`references/godot-version.md`](../../references/godot-version.md) — Summer Engine multiplayer API stability notes.
 - [`references/gd-style.md`](../../references/gd-style.md) — typed-GDScript conventions used in the examples above.
 - [`references/mcp-tools-reference.md`](../../references/mcp-tools-reference.md) — `summer_get_script_errors` for compile verification.

--- a/skills/multiplayer-and-networking/peer-to-peer-multiplayer/SKILL.md
+++ b/skills/multiplayer-and-networking/peer-to-peer-multiplayer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: peer-to-peer-multiplayer
-description: Use when starting a multiplayer Godot game from scratch — peer-to-peer with host authority. Build the network architecture top-down so authoritative state, routing rules, and real-time rendering aren't bolted on later. Use BEFORE writing game logic, not after. Trigger on "multiplayer", "peer-to-peer", "p2p", "co-op", "host", "multiplayer architecture", "add multiplayer".
+description: Use when starting a multiplayer Summer game from scratch — peer-to-peer with host authority. Build the network architecture top-down so authoritative state, routing rules, and real-time rendering aren't bolted on later. Use BEFORE writing game logic, not after. Trigger on "multiplayer", "peer-to-peer", "p2p", "co-op", "host", "multiplayer architecture", "add multiplayer".
 license: MIT
 compatibility: [Cursor, Claude Code, Windsurf, Codex]
 category: multiplayer-and-networking
@@ -371,7 +371,7 @@ When the `template-co-op-3d` template ships in the registry, this skill will ref
 
 ## See also
 
-- [`references/godot-version.md`](../../references/godot-version.md) — Godot 4.5 multiplayer API stability notes
+- [`references/godot-version.md`](../../references/godot-version.md) — Summer Engine multiplayer API stability notes
 - [`references/mcp-tools-reference.md`](../../references/mcp-tools-reference.md) — `summer_project_setting` for autoload registration
 - [`references/gd-style.md`](../../references/gd-style.md) — typed-GDScript conventions
 - [`host-authoritative-state`](../host-authoritative-state/SKILL.md) — deeper dive on JUST the state ownership decision matrix

--- a/skills/performance/tune-performance/SKILL.md
+++ b/skills/performance/tune-performance/SKILL.md
@@ -73,7 +73,7 @@ Decision tree:
 
 ### 4a. Rendering hotspot
 
-Common Godot 4.5 rendering costs, ordered by frequency:
+Common Summer Engine rendering costs, ordered by frequency:
 
 | Pattern | Symptom | Fix |
 |---|---|---|
@@ -209,7 +209,7 @@ No template — this is a workflow. Performance tuning is project-specific by de
 ## See also
 
 - `references/mcp-tools-reference.md` — full MCP tool list
-- `references/godot-version.md` — Godot 4.5 renderer notes (Compositor, RenderSceneBuffers churn)
+- `references/godot-version.md` — Summer Engine renderer notes (Compositor, RenderSceneBuffers churn)
 - `references/collaborative-protocol.md` — "May I write" pattern
 - `references/gd-style.md` — GDScript conventions (avoid bare types, use `:=`)
 - `performance/profiling-godot/SKILL.md` — deeper Godot profiler usage

--- a/skills/rendering-and-lighting/3d-lighting/SKILL.md
+++ b/skills/rendering-and-lighting/3d-lighting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 3d-lighting
-description: Use when setting up lighting in a 3D scene — adding lights, configuring WorldEnvironment, sky, or shadows. Covers DirectionalLight3D vs Omni vs Spot, shadow tuning, ambient/sky-driven lighting, and Godot 4.5-era conventions. Trigger on "lighting", "shadows", "WorldEnvironment", "sun", "ambient", "sky", "light".
+description: Use when setting up lighting in a 3D scene — adding lights, configuring WorldEnvironment, sky, or shadows. Covers DirectionalLight3D vs Omni vs Spot, shadow tuning, ambient/sky-driven lighting, and current Summer Engine conventions. Trigger on "lighting", "shadows", "WorldEnvironment", "sun", "ambient", "sky", "light".
 license: MIT
 compatibility: [Cursor, Claude Code, Windsurf, Codex]
 category: rendering-and-lighting

--- a/skills/rendering-and-lighting/art-direction/SKILL.md
+++ b/skills/rendering-and-lighting/art-direction/SKILL.md
@@ -113,7 +113,7 @@ Ask:
 
 ### 6. Write the lighting plan
 
-State the plan in one block. For Godot 4.5:
+State the plan in one block. For Summer Engine:
 
 ```
 Sun: DirectionalLight3D, color #fff2d9, energy 0.9, angle ~30° (warm low-angle)
@@ -133,7 +133,7 @@ NEVER: full-bright modulation, no soft falloff
 
 ### 7. Define post-processing rules
 
-Godot 4.5 post stack: Glow, SDFGI, SSAO, SSR, Adjustments, Color Correction (LUT). State opinions, not options.
+Summer Engine post stack: Glow, SDFGI, SSAO, SSR, Adjustments, Color Correction (LUT). State opinions, not options.
 
 ```
 Glow: ON, threshold 0.9, intensity 0.5  (soft bloom on highlights only)
@@ -274,7 +274,7 @@ No template — this is a workflow that produces the bible the rest of the proje
 ## See also
 
 - `references/collaborative-protocol.md`
-- `references/godot-version.md` — Godot 4.5 rendering API notes (Compositor moved in 4.4 / 4.5)
+- `references/godot-version.md` — Summer Engine rendering API notes (Compositor moved in 4.4 / 4.5)
 - `references/mcp-tools-reference.md`
 - `scene-and-project/brainstorm-game/SKILL.md` — produces the brief that anchors the bible
 - `audio/audio-direction/SKILL.md` — the sonic counterpart

--- a/skills/scene-and-project/make-game/SKILL.md
+++ b/skills/scene-and-project/make-game/SKILL.md
@@ -198,7 +198,7 @@ Use `summer:asset-strategy` to decide whether to generate assets, search the lib
 Skill: summer:vfx
 ```
 
-Walks the canonical Godot 4.5 game-feel stack — hit-flash + trauma camera shake + audio ducking — wired so a single hit fires all three.
+Walks the canonical Summer Engine game-feel stack — hit-flash + trauma camera shake + audio ducking — wired so a single hit fires all three.
 
 ```
 Skill: summer:tune-performance

--- a/skills/visual-effects/game-feel/SKILL.md
+++ b/skills/visual-effects/game-feel/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: game-feel
-description: Use when the user says the game "feels flat", "lacks impact", "needs juice", "needs punch", or asks for hit feedback, screen shake, camera shake, audio ducking, or general "game feel". Walks the user through the canonical Godot 4.5 game-feel stack — hit-flash + trauma camera shake + audio ducking — wired together so a single hit fires all three. Trigger on "vfx", "juice", "punch", "feels flat", "game feel", "hit flash", "screen shake", "camera shake", "ducking".
+description: Use when the user says the game "feels flat", "lacks impact", "needs juice", "needs punch", or asks for hit feedback, screen shake, camera shake, audio ducking, or general "game feel". Walks the user through the canonical Summer Engine game-feel stack — hit-flash + trauma camera shake + audio ducking — wired together so a single hit fires all three. Trigger on "vfx", "juice", "punch", "feels flat", "game feel", "hit flash", "screen shake", "camera shake", "ducking".
 license: MIT
 compatibility: [Cursor, Claude Code, Windsurf, Codex]
 category: visual-effects
@@ -11,7 +11,7 @@ paths: ["**/*.gd", "**/*.tscn", "**/*.tres"]
 
 # /vfx — The Trio That Makes Games Feel Punchy
 
-Particles don't make a game feel good. Screen shake alone doesn't either. What makes a hit *land in the body* is three systems firing on the same frame: a sub-frame **hit flash** on the body that got hit, **trauma-based camera shake** with quadratic falloff so big hits saturate, and **audio ducking** that briefly squashes Music/Ambient so the impact SFX punches through. Skip any one and the game drops back to "tech demo". This skill installs the canonical Godot 4.5 stack — three small, self-contained systems wired to a single signal — so one `hit()` call fires all three.
+Particles don't make a game feel good. Screen shake alone doesn't either. What makes a hit *land in the body* is three systems firing on the same frame: a sub-frame **hit flash** on the body that got hit, **trauma-based camera shake** with quadratic falloff so big hits saturate, and **audio ducking** that briefly squashes Music/Ambient so the impact SFX punches through. Skip any one and the game drops back to "tech demo". This skill installs the canonical Summer Engine stack — three small, self-contained systems wired to a single signal — so one `hit()` call fires all three.
 
 ## Step 1 — Ask what feels flat
 
@@ -370,7 +370,7 @@ This skill writes 3 GDScript files and adds 1 node + 1 autoload entry. Always as
 ## See also
 
 - `references/mcp-tools-reference.md` — full MCP tool list, especially the inline-sub_resource trap
-- `references/godot-version.md` — Godot 4.5 API notes
+- `references/godot-version.md` — Summer Engine API notes
 - `references/collaborative-protocol.md` — "May I write" pattern
 - `references/gd-style.md` — typed GDScript conventions
 - `audio/audio-direction/SKILL.md` — bus layout setup (prerequisite for ducking)

--- a/skills/workflow/using-summer/SKILL.md
+++ b/skills/workflow/using-summer/SKILL.md
@@ -38,10 +38,11 @@ Two layers:
 - **Skills** — discipline guides that fire on specific situations: brainstorming a game, designing a mechanic, building an FPS controller, debugging a crash, shipping a build. Each one is a SKILL.md you load via the Skill tool.
 - **MCP tools** — `summer_*` tools that talk to the running Summer Engine on `localhost:6550`. Scene mutation (`summer_add_node`, `summer_set_prop`), inspection (`summer_get_scene_tree`, `summer_inspect_node`), play/diagnostics (`summer_play`, `summer_get_diagnostics`), asset import/generation (`summer_import_from_url`, `summer_generate_3d`), whole-project sync to Summer Cloud (`summer_cloud_push`, `summer_cloud_pull`; see `summer:summer-cloud`), and 30+ more.
 
-**Scripting language:** Summer Engine is compatible with Godot 4.5. You can write game code in either:
+**Scripting language:** You are making a Summer game with the Summer SDK. You
+can write game code in either:
 
 - **GDScript** (`.gd`) — the default. Best supported by Summer skills (see `summer:gdscript-patterns`). Use this unless the user has explicitly chosen C#.
-- **C#** (`.cs`) — fully supported by the engine. There is no `summer:csharp-patterns` skill yet — when writing C#, use the Godot 4.5 C# API from first principles. The patterns are different (different lifecycle method names, different signal API, different export attributes), so don't blindly translate GDScript idioms. Confirm with the user that they want C# before producing it; switching languages mid-project is painful.
+- **C#** (`.cs`) — fully supported by the engine. There is no `summer:csharp-patterns` skill yet — when writing C#, use the Summer Engine C# API from first principles. The patterns are different (different lifecycle method names, different signal API, different export attributes), so don't blindly translate GDScript idioms. Confirm with the user that they want C# before producing it; switching languages mid-project is painful.
 
 Scenes are always `.tscn`/`.scn`. Resources are always `.tres`/`.res`. Drive the engine through `summer_*` tools — do not hand-edit `.tscn` files; the editor holds in-memory state that diverges from disk.
 

--- a/src/bin/summer.ts
+++ b/src/bin/summer.ts
@@ -19,6 +19,10 @@ import { doctorCommand } from "../commands/doctor.js";
 import { planCommand } from "../commands/plan.js";
 import { cloudCommand } from "../commands/cloud.js";
 import { debugCommand } from "../commands/debug.js";
+import { configCommand } from "../commands/config.js";
+import { publishCommand } from "../commands/publish.js";
+import { releasesCommand } from "../commands/releases.js";
+import { logsCommand } from "../commands/logs.js";
 import { getBanner } from "../lib/banner.js";
 import { c, sym } from "../lib/format.js";
 
@@ -52,6 +56,10 @@ program.addCommand(debugCommand);
 program.addCommand(planCommand);
 program.addCommand(orchestratorCommand);
 program.addCommand(cloudCommand);
+program.addCommand(configCommand);
+program.addCommand(publishCommand);
+program.addCommand(releasesCommand);
+program.addCommand(logsCommand);
 
 program.parseAsync().catch((err) => {
   console.error(err instanceof Error ? err.message : String(err));

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,71 @@
+import { Command } from "commander";
+import {
+  CONFIG_KEYS,
+  getConfigValue,
+  isConfigKey,
+  readSummerConfig,
+  setConfigValue,
+  unsetConfigValue,
+} from "../lib/config.js";
+
+function requireKey(value: string) {
+  if (isConfigKey(value)) return value;
+  throw new Error(
+    `Unknown config key "${value}". Recovery: use one of ${CONFIG_KEYS.join(", ")}.`
+  );
+}
+
+async function printConfig(json: boolean): Promise<void> {
+  const config = await readSummerConfig();
+  const values = Object.fromEntries(
+    CONFIG_KEYS.map((key) => [key, getConfigValue(config, key) ?? null])
+  );
+  if (json) {
+    console.log(JSON.stringify(values, null, 2));
+    return;
+  }
+  for (const [key, value] of Object.entries(values)) {
+    console.log(`${key}=${value ?? "(not set)"}`);
+  }
+}
+
+export const configCommand = new Command("config")
+  .description("Read or update the shared ~/.summer configuration")
+  .option("--json", "Print all configuration as JSON")
+  .action(async (opts: { json?: boolean }) => printConfig(Boolean(opts.json)));
+
+configCommand
+  .command("get")
+  .description("Read one configuration value")
+  .argument("<key>", `One of: ${CONFIG_KEYS.join(", ")}`)
+  .action(async (rawKey: string) => {
+    const key = requireKey(rawKey);
+    const value = getConfigValue(await readSummerConfig(), key);
+    if (value === undefined) {
+      throw new Error(
+        `${key} is not set. Recovery: run "summer config set ${key} <value>", or rely on the documented default.`
+      );
+    }
+    console.log(value);
+  });
+
+configCommand
+  .command("set")
+  .description("Set one non-secret configuration value")
+  .argument("<key>", `One of: ${CONFIG_KEYS.join(", ")}`)
+  .argument("<value>")
+  .action(async (rawKey: string, value: string) => {
+    const key = requireKey(rawKey);
+    await setConfigValue(key, value);
+    console.log(`Set ${key}.`);
+  });
+
+configCommand
+  .command("unset")
+  .description("Remove one configuration override")
+  .argument("<key>", `One of: ${CONFIG_KEYS.join(", ")}`)
+  .action(async (rawKey: string) => {
+    const key = requireKey(rawKey);
+    await unsetConfigValue(key);
+    console.log(`Unset ${key}.`);
+  });

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -115,7 +115,7 @@ function projectGodot(name: string, mainScene: string): string {
 
 config/name="${name}"
 run/main_scene="${mainScene}"
-config/features=PackedStringArray("4.5")
+config/features=PackedStringArray("4.6")
 
 [rendering]
 

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -5,7 +5,13 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { downloadFile, requireDownloadUrl, verifyChecksum, windowsInstallerArgs } from "./install.js";
+import {
+  downloadFile,
+  requireDownloadUrl,
+  unsupportedInstallPlatformMessage,
+  verifyChecksum,
+  windowsInstallerArgs,
+} from "./install.js";
 
 describe("requireDownloadUrl", () => {
   it("returns a present URL", () => {
@@ -43,6 +49,17 @@ describe("windowsInstallerArgs (Velopack Setup.exe — NOT NSIS)", () => {
     expect(args).toContain("--silent");
     expect(args).toContain('--installto "C:\\Apps\\Summer Engine"');
     expect(args).not.toContain("/D=");
+  });
+});
+
+describe("unsupportedInstallPlatformMessage", () => {
+  it("names the shipping installers and does not imply a manual Linux download exists", () => {
+    const message = unsupportedInstallPlatformMessage();
+    expect(message).toContain("macOS on Apple silicon and Windows");
+    expect(message).toContain("Linux does not have a supported public installer");
+    expect(message).toContain("no manual Linux download is available");
+    expect(message).not.toContain("summerengine.com/download");
+    expect(message).not.toMatch(/download manually|for now, download/i);
   });
 });
 

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -51,6 +51,14 @@ export function windowsInstallerArgs(customPath?: string): string {
   return customPath ? `--silent --installto "${customPath}"` : "--silent";
 }
 
+export function unsupportedInstallPlatformMessage(): string {
+  return (
+    "summer install currently supports macOS on Apple silicon and Windows.\n" +
+    "Linux does not have a supported public installer yet. Linux support is planned; " +
+    "no manual Linux download is available."
+  );
+}
+
 export const installCommand = new Command("install")
   .description("Download and install Summer Engine")
   .option("--path <dir>", "Custom install directory")
@@ -58,10 +66,7 @@ export const installCommand = new Command("install")
     const os = platform();
 
     if (os !== "darwin" && os !== "win32") {
-      console.error(
-        "Linux support is coming soon.\n" +
-        "For now, download from: https://summerengine.com/download"
-      );
+      console.error(unsupportedInstallPlatformMessage());
       process.exit(1);
     }
 

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getAuthToken,
+  getCreatorToken,
+  getUserInfo,
+} from "../lib/auth.js";
+import { setConfigValue } from "../lib/config.js";
+import { setSummerDirForTests } from "../lib/store.js";
+import { runCreatorLogin, runLogin } from "./login.js";
+
+let root = "";
+const originalGateway = process.env.SUMMER_GATEWAY_URL;
+
+function cliToken(): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({
+      sub: "user-1",
+      type: "cli",
+      aud: "summer-cli",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    })
+  ).toString("base64url");
+  return `${header}.${payload}.signature`;
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "summer-login-test-"));
+  setSummerDirForTests(join(root, ".summer"));
+  process.env.SUMMER_GATEWAY_URL = "https://gateway.example";
+});
+
+afterEach(async () => {
+  setSummerDirForTests(null);
+  if (originalGateway === undefined) delete process.env.SUMMER_GATEWAY_URL;
+  else process.env.SUMMER_GATEWAY_URL = originalGateway;
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("runLogin", () => {
+  it("uses the current browser/poll contract and persists one validated session", async () => {
+    const logs: string[] = [];
+    const openUrl = vi.fn(async () => undefined);
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          status: "complete",
+          token: cliToken(),
+          user: {
+            id: "user-1",
+            email: "maker@example.com",
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+
+    await runLogin({
+      randomId: () => "session-123",
+      openUrl,
+      fetch: fetchMock as typeof fetch,
+      sleep: async () => undefined,
+      now: () => 1,
+      log: (message) => logs.push(message),
+    });
+
+    expect(openUrl).toHaveBeenCalledWith(
+      "https://gateway.example/login?cli_session=session-123"
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example/api/auth/cli-login?session=session-123",
+      expect.any(Object)
+    );
+    expect(await getAuthToken()).toBe(cliToken());
+    expect(await getUserInfo()).toMatchObject({
+      id: "user-1",
+      email: "maker@example.com",
+    });
+    expect(logs.at(-1)).toContain("maker@example.com");
+  });
+});
+
+describe("runCreatorLogin", () => {
+  it("opens scoped token settings and stores creator auth separately", async () => {
+    const logs: string[] = [];
+    const openUrl = vi.fn(async () => undefined);
+    const creatorToken = `sc_${"b".repeat(43)}`;
+    await setConfigValue("creator.apiUrl", "https://creator.example");
+
+    await runCreatorLogin({
+      openUrl,
+      readSecret: async () => creatorToken,
+      log: (message) => logs.push(message),
+    });
+
+    expect(openUrl).toHaveBeenCalledWith(
+      "https://creator.example/creator/settings/tokens"
+    );
+    expect(await getCreatorToken()).toBe(creatorToken);
+    expect(await getAuthToken()).toBeNull();
+    expect(logs.at(-1)).toContain("core Summer login token was not changed");
+  });
+});

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,60 +1,185 @@
 import { Command } from "commander";
 import { randomUUID } from "crypto";
 import open from "open";
-import { getAuthToken, saveAuthToken, saveCloudToken, saveUserInfo } from "../lib/auth.js";
-
-const GATEWAY_URL =
-  process.env.SUMMER_GATEWAY_URL || "https://www.summerengine.com";
+import {
+  getAuthToken,
+  getCreatorToken,
+  saveCreatorToken,
+  saveLoginSession,
+} from "../lib/auth.js";
+import { getCreatorApiUrl, getGatewayUrl } from "../lib/config.js";
 
 const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 120000;
 
 export const loginCommand = new Command("login")
   .description("Sign in to Summer Engine via your browser")
+  .option(
+    "--creator",
+    "Connect a separately scoped Summercraft creator token for publishing"
+  )
   .option("--force", "Force re-authentication even if already logged in")
-  .action(async (opts: { force?: boolean }) => {
+  .action(async (opts: { creator?: boolean; force?: boolean }) => {
+    if (opts.creator) {
+      const existingCreator = await getCreatorToken();
+      if (existingCreator && !opts.force) {
+        console.log(
+          "A creator token is already connected. Use --creator --force to replace it."
+        );
+        return;
+      }
+      await runCreatorLogin();
+      return;
+    }
+
     const existing = await getAuthToken();
     if (existing && !opts.force) {
       console.log("Already logged in. Use --force to re-authenticate.");
       return;
     }
 
-    await doLogin();
+    await runLogin();
   });
 
-async function doLogin(): Promise<void> {
-  const sessionId = randomUUID();
+export interface CreatorLoginDependencies {
+  openUrl: (url: string) => Promise<unknown>;
+  readSecret: (prompt: string) => Promise<string>;
+  log: (message: string) => void;
+}
 
-  const loginUrl = `${GATEWAY_URL}/login?cli_session=${sessionId}`;
-  console.log("Sign in at: " + loginUrl);
-  console.log("");
-
-  try {
-    await open(loginUrl);
-  } catch {
-    console.log("Could not open browser. Copy the URL above and open it manually.");
-    console.log("");
+async function readHiddenLine(prompt: string): Promise<string> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    process.stdout.write(prompt);
+    let value = "";
+    for await (const chunk of process.stdin) value += String(chunk);
+    return value.trim();
   }
 
-  console.log("Waiting for authentication...");
+  process.stdout.write(prompt);
+  const input = process.stdin;
+  const wasRaw = input.isRaw;
+  input.setRawMode(true);
+  input.resume();
+  return new Promise<string>((resolve, reject) => {
+    let value = "";
+    const finish = (error?: Error) => {
+      input.off("data", onData);
+      input.setRawMode(Boolean(wasRaw));
+      input.pause();
+      process.stdout.write("\n");
+      if (error) reject(error);
+      else resolve(value.trim());
+    };
+    const onData = (chunk: Buffer | string) => {
+      for (const char of String(chunk)) {
+        if (char === "\u0003") {
+          finish(new Error("Creator token entry cancelled."));
+          return;
+        }
+        if (char === "\r" || char === "\n" || char === "\u0004") {
+          finish();
+          return;
+        }
+        if (char === "\u007f" || char === "\b") {
+          value = value.slice(0, -1);
+        } else if (char >= " ") {
+          value += char;
+        }
+      }
+    };
+    input.on("data", onData);
+  });
+}
 
-  const pollUrl = `${GATEWAY_URL}/api/auth/cli-login?session=${sessionId}`;
-  const startTime = Date.now();
+const defaultCreatorLoginDependencies: CreatorLoginDependencies = {
+  openUrl: open,
+  readSecret: readHiddenLine,
+  log: console.log,
+};
+
+/**
+ * The browser session mints the token; the token is pasted once into a hidden
+ * prompt. This deliberately does not replace the core Summer login JWT.
+ */
+export async function runCreatorLogin(
+  overrides: Partial<CreatorLoginDependencies> = {}
+): Promise<void> {
+  const deps = { ...defaultCreatorLoginDependencies, ...overrides };
+  const settingsUrl = `${await getCreatorApiUrl()}/creator/settings/tokens`;
+  deps.log(`Opening creator token settings: ${settingsUrl}`);
+  deps.log(
+    'Mint a token with the exact "publish" scope, copy its one-time sc_ value, then return here.'
+  );
+  try {
+    await deps.openUrl(settingsUrl);
+  } catch {
+    deps.log("Could not open the browser. Copy the URL above and open it manually.");
+  }
+  const token = await deps.readSecret("Creator token (input hidden): ");
+  await saveCreatorToken(token);
+  deps.log(
+    "Creator publishing connected. Your core Summer login token was not changed."
+  );
+}
+
+export interface LoginDependencies {
+  fetch: typeof fetch;
+  openUrl: (url: string) => Promise<unknown>;
+  randomId: () => string;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+  log: (message: string) => void;
+}
+
+const defaultDependencies: LoginDependencies = {
+  fetch,
+  openUrl: open,
+  randomId: randomUUID,
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  now: Date.now,
+  log: console.log,
+};
+
+export async function runLogin(
+  overrides: Partial<LoginDependencies> = {}
+): Promise<void> {
+  const deps = { ...defaultDependencies, ...overrides };
+  const gatewayUrl = await getGatewayUrl();
+  const sessionId = deps.randomId();
+
+  const loginUrl = `${gatewayUrl}/login?cli_session=${encodeURIComponent(sessionId)}`;
+  deps.log("Sign in at: " + loginUrl);
+  deps.log("");
+
+  try {
+    await deps.openUrl(loginUrl);
+  } catch {
+    deps.log("Could not open browser. Copy the URL above and open it manually.");
+    deps.log("");
+  }
+
+  deps.log("Waiting for authentication...");
+
+  const pollUrl = `${gatewayUrl}/api/auth/cli-login?session=${encodeURIComponent(sessionId)}`;
+  const startTime = deps.now();
   let lastError: string | null = null;
 
-  while (Date.now() - startTime < POLL_TIMEOUT_MS) {
-    await sleep(POLL_INTERVAL_MS);
+  while (deps.now() - startTime < POLL_TIMEOUT_MS) {
+    await deps.sleep(POLL_INTERVAL_MS);
 
     try {
-      const res = await fetch(pollUrl, {
+      const res = await deps.fetch(pollUrl, {
         signal: AbortSignal.timeout(5000),
       });
 
       if (!res.ok) {
         if (res.status === 503) {
-          lastError = "Server not ready (Redis/auth not configured). Try again later.";
+          lastError =
+            "The login service is unavailable (Redis/auth is not configured).";
+        } else if (res.status >= 400 && res.status < 500) {
+          lastError = `The login request was rejected (${res.status}).`;
         } else if (res.status >= 500) {
-          lastError = `Server error (${res.status}). Try again later.`;
+          lastError = `The login service failed (${res.status}).`;
         }
         continue;
       }
@@ -64,34 +189,30 @@ async function doLogin(): Promise<void> {
         token?: string;
         cloudToken?: string | null;
         user?: { id: string; email: string; name?: string };
+        scopes?: string[];
+        cloudScopes?: string[];
       };
 
       if (data.status === "pending") continue;
 
       if (data.status === "complete" && data.token) {
-        await saveAuthToken(data.token);
-        if (data.cloudToken) {
-          await saveCloudToken(data.cloudToken);
-        }
-        if (data.user) {
-          await saveUserInfo(data.user);
-        }
-        console.log(`\nLogged in as ${data.user?.email || "unknown"}`);
+        await saveLoginSession({
+          token: data.token,
+          cloudToken: data.cloudToken,
+          user: data.user,
+          scopes: data.scopes,
+          cloudScopes: data.cloudScopes,
+        });
+        deps.log(`\nLogged in as ${data.user?.email || "unknown"}`);
         return;
       }
+      lastError = "The login service returned an incomplete authentication result.";
     } catch (err) {
       lastError = err instanceof Error ? err.message : "Network error";
     }
   }
 
-  console.error("\nLogin timed out. Please try again.");
-  if (lastError) {
-    console.error(`Last error: ${lastError}`);
-  }
-  console.error("\nDid you click \"Yes, Sign In\" in the browser after opening the URL?");
-  process.exit(1);
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  throw new Error(
+    `Login timed out after 120 seconds.${lastError ? ` Last error: ${lastError}` : ""} Recovery: run "summer login" again, complete "Yes, Sign In" in the browser, and return to the terminal within two minutes.`
+  );
 }

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,25 +1,11 @@
 import { Command } from "commander";
-import { unlink } from "fs/promises";
-import { join } from "path";
-import { getSummerDir } from "../lib/auth.js";
+import { clearAuthCredentials } from "../lib/auth.js";
 
 export const logoutCommand = new Command("logout")
   .description("Sign out and clear stored auth tokens")
   .action(async () => {
-    const dir = getSummerDir();
-    const files = ["auth-token", "cloud-token", "user.json"];
-
-    let cleared = false;
-    for (const file of files) {
-      try {
-        await unlink(join(dir, file));
-        cleared = true;
-      } catch {
-        // File doesn't exist, that's fine
-      }
-    }
-
-    if (cleared) {
+    const removed = await clearAuthCredentials();
+    if (removed > 0) {
       console.log("Logged out. Auth tokens cleared.");
     } else {
       console.log("Already logged out (no tokens found).");

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -1,0 +1,24 @@
+import { Command } from "commander";
+import { readCreatorLogs } from "../lib/creator.js";
+
+export const logsCommand = new Command("logs")
+  .description("Read creator runtime logs")
+  .option("--project-id <id>", "Creator project ID")
+  .option("--release <id>", "Restrict logs to one release")
+  .option("--limit <count>", "Maximum log entries to return", "100")
+  .action(
+    async (opts: { projectId?: string; release?: string; limit: string }) => {
+      const limit = Number.parseInt(opts.limit, 10);
+      if (!Number.isInteger(limit) || limit < 1 || limit > 1000) {
+        throw new Error(
+          "--limit must be between 1 and 1000. Recovery: pass a whole number in that range."
+        );
+      }
+      await readCreatorLogs({
+        projectId: opts.projectId,
+        releaseId: opts.release,
+        limit,
+        face: "cli",
+      });
+    }
+  );

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,0 +1,37 @@
+import { Command } from "commander";
+import { publishCreator } from "../lib/creator.js";
+
+export const publishCommand = new Command("publish")
+  .description("Publish a confirmed creator release")
+  .argument("[project]", "Project root. Defaults to the current directory.")
+  .requiredOption("--artifact <path>", "Exact exported Summer .pck artifact")
+  .requiredOption("--version <value>", "Immutable release version")
+  .option("--manifest <path>", "Optional JSON release manifest")
+  .option("--project-id <id>", "Creator project ID")
+  .option("--channel <name>", "Release channel")
+  .option("--notes <text>", "Release notes")
+  .option(
+    "--confirm",
+    "Confirm the exact project and channel after reviewing them"
+  )
+  .action(
+    async (
+      project: string | undefined,
+      opts: {
+        artifact: string;
+        version: string;
+        manifest?: string;
+        projectId?: string;
+        channel?: string;
+        notes?: string;
+        confirm?: boolean;
+      }
+    ) => {
+      const result = await publishCreator({
+        project,
+        ...opts,
+        face: "cli",
+      });
+      console.log(JSON.stringify(result, null, 2));
+    }
+  );

--- a/src/commands/releases.ts
+++ b/src/commands/releases.ts
@@ -1,0 +1,23 @@
+import { Command } from "commander";
+import { listCreatorReleases } from "../lib/creator.js";
+
+export const releasesCommand = new Command("releases")
+  .description("List creator releases for a project")
+  .option("--project-id <id>", "Creator project ID")
+  .option("--limit <count>", "Maximum releases to return", "20")
+  .option("--cursor <value>", "Opaque cursor returned by the previous page")
+  .action(async (opts: { projectId?: string; limit: string; cursor?: string }) => {
+    const limit = Number.parseInt(opts.limit, 10);
+    if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+      throw new Error(
+        "--limit must be between 1 and 100. Recovery: pass a whole number in that range."
+      );
+    }
+    const result = await listCreatorReleases({
+      projectId: opts.projectId,
+      limit,
+      cursor: opts.cursor,
+      face: "cli",
+    });
+    console.log(JSON.stringify(result, null, 2));
+  });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,66 +1,274 @@
-import { readFile, writeFile, mkdir } from "fs/promises";
-import { existsSync } from "fs";
-import { join } from "path";
-import { homedir } from "os";
+import {
+  getSummerDir,
+  readStoreJson,
+  readStoreText,
+  removeStoreFile,
+  writeStoreJson,
+  writeStoreText,
+} from "./store.js";
 
-const SUMMER_DIR = join(homedir(), ".summer");
+export { getSummerDir } from "./store.js";
 
-export function getSummerDir(): string {
-  return SUMMER_DIR;
+const AUTH_TOKEN_FILE = "auth-token";
+const CLOUD_TOKEN_FILE = "cloud-token";
+const CREATOR_TOKEN_FILE = "creator-token";
+const USER_FILE = "user.json";
+const METADATA_FILE = "credential-metadata.json";
+
+export interface SummerUserInfo {
+  id: string;
+  email: string;
+  name?: string;
 }
 
-async function ensureSummerDir(): Promise<void> {
-  if (!existsSync(SUMMER_DIR)) {
-    await mkdir(SUMMER_DIR, { recursive: true, mode: 0o700 });
+export interface CredentialMetadata {
+  audience: string[];
+  scopes: string[];
+  tokenType?: string;
+  issuedAt?: string;
+  expiresAt?: string;
+}
+
+interface CredentialMetadataDocument {
+  schemaVersion: 1;
+  auth?: CredentialMetadata;
+  cloud?: CredentialMetadata;
+  creator?: CredentialMetadata;
+}
+
+export interface LoginSession {
+  token: string;
+  cloudToken?: string | null;
+  user?: SummerUserInfo;
+  scopes?: string[];
+  cloudScopes?: string[];
+}
+
+function decodeJwtMetadata(
+  token: string,
+  explicitScopes: string[] = []
+): CredentialMetadata {
+  const payload = decodeJwtPayload(token);
+  const aud = payload.aud;
+  const audience =
+    typeof aud === "string"
+      ? [aud]
+      : Array.isArray(aud)
+        ? aud.filter((value): value is string => typeof value === "string")
+        : [];
+  const claimScopes =
+    typeof payload.scope === "string"
+      ? payload.scope.split(/\s+/)
+      : Array.isArray(payload.scp)
+        ? payload.scp.filter((value): value is string => typeof value === "string")
+        : [];
+  const scopes = [...new Set([...explicitScopes, ...claimScopes].filter(Boolean))].sort();
+  const issuedAt =
+    typeof payload.iat === "number"
+      ? new Date(payload.iat * 1000).toISOString()
+      : undefined;
+  const expiresAt =
+    typeof payload.exp === "number"
+      ? new Date(payload.exp * 1000).toISOString()
+      : undefined;
+
+  return {
+    audience,
+    scopes,
+    ...(typeof payload.type === "string" ? { tokenType: payload.type } : {}),
+    ...(issuedAt ? { issuedAt } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
+  };
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  try {
+    const encoded = token.split(".")[1];
+    if (encoded) {
+      return JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")) as Record<
+        string,
+        unknown
+      >;
+    }
+  } catch {
+    // Metadata is advisory only. The gateway verifies the signature.
   }
+  return {};
+}
+
+async function readMetadata(): Promise<CredentialMetadataDocument> {
+  return (
+    (await readStoreJson<CredentialMetadataDocument>(METADATA_FILE)) ?? {
+      schemaVersion: 1,
+    }
+  );
+}
+
+async function updateMetadata(
+  kind: "auth" | "cloud" | "creator",
+  value: CredentialMetadata | undefined
+): Promise<void> {
+  const current = await readMetadata();
+  const next: CredentialMetadataDocument = {
+    ...current,
+    schemaVersion: 1,
+    [kind]: value,
+  };
+  if (!next.auth) delete next.auth;
+  if (!next.cloud) delete next.cloud;
+  if (!next.creator) delete next.creator;
+  await writeStoreJson(METADATA_FILE, next);
 }
 
 export async function getAuthToken(): Promise<string | null> {
-  try {
-    const token = await readFile(join(SUMMER_DIR, "auth-token"), "utf-8");
-    return token.trim() || null;
-  } catch {
-    return null;
-  }
+  const token = await readStoreText(AUTH_TOKEN_FILE);
+  return token?.trim() || null;
 }
 
-export async function saveAuthToken(token: string): Promise<void> {
-  await ensureSummerDir();
-  await writeFile(join(SUMMER_DIR, "auth-token"), token, { encoding: "utf-8", mode: 0o600 });
+export async function saveAuthToken(
+  token: string,
+  scopes: string[] = []
+): Promise<void> {
+  const clean = token.trim();
+  if (!clean) throw new Error("Cannot save an empty auth token.");
+  await writeStoreText(AUTH_TOKEN_FILE, `${clean}\n`);
+  await updateMetadata("auth", decodeJwtMetadata(clean, scopes));
 }
 
 export async function getCloudToken(): Promise<string | null> {
-  try {
-    const token = await readFile(join(SUMMER_DIR, "cloud-token"), "utf-8");
-    return token.trim() || null;
-  } catch {
-    return null;
+  const token = await readStoreText(CLOUD_TOKEN_FILE);
+  return token?.trim() || null;
+}
+
+export async function saveCloudToken(
+  token: string,
+  scopes: string[] = []
+): Promise<void> {
+  const clean = token.trim();
+  if (!clean) throw new Error("Cannot save an empty cloud token.");
+  await writeStoreText(CLOUD_TOKEN_FILE, `${clean}\n`);
+  await updateMetadata("cloud", decodeJwtMetadata(clean, scopes));
+}
+
+/**
+ * Summercraft creator tokens are a separate credential audience from the
+ * core-compatible Summer CLI JWT. Never store an sc_ token in auth-token:
+ * the engine reads that file and expects the summer-cli JWT contract.
+ */
+export async function getCreatorToken(): Promise<string | null> {
+  const token = await readStoreText(CREATOR_TOKEN_FILE);
+  return token?.trim() || null;
+}
+
+export async function saveCreatorToken(token: string): Promise<void> {
+  const clean = token.trim();
+  if (!/^sc_[A-Za-z0-9_-]{32,}$/.test(clean)) {
+    throw new Error(
+      'That is not a Summercraft creator API token. Recovery: open /creator/settings/tokens, mint a token with the "publish" scope, and paste the complete one-time sc_ value.'
+    );
   }
+  await writeStoreText(CREATOR_TOKEN_FILE, `${clean}\n`);
+  await updateMetadata("creator", {
+    audience: ["summercraft-creator"],
+    scopes: ["publish"],
+    tokenType: "api",
+  });
 }
 
-export async function saveCloudToken(token: string): Promise<void> {
-  await ensureSummerDir();
-  await writeFile(join(SUMMER_DIR, "cloud-token"), token, { encoding: "utf-8", mode: 0o600 });
+export async function getUserInfo(): Promise<SummerUserInfo | null> {
+  return readStoreJson<SummerUserInfo>(USER_FILE);
 }
 
-export async function getUserInfo(): Promise<{
-  id: string;
-  email: string;
-  name?: string;
-} | null> {
-  try {
-    const data = await readFile(join(SUMMER_DIR, "user.json"), "utf-8");
-    return JSON.parse(data);
-  } catch {
-    return null;
+export async function saveUserInfo(info: SummerUserInfo): Promise<void> {
+  await writeStoreJson(USER_FILE, info);
+}
+
+export async function saveLoginSession(session: LoginSession): Promise<void> {
+  const payload = decodeJwtPayload(session.token);
+  if (
+    !session.user ||
+    typeof payload.sub !== "string" ||
+    payload.sub !== session.user.id
+  ) {
+    throw new Error(
+      'The gateway returned an incomplete or mismatched identity. Recovery: run "summer login --force" again; if it repeats, report the CLI login endpoint as unhealthy.'
+    );
   }
+  const metadata = decodeJwtMetadata(session.token, session.scopes);
+  if (
+    metadata.tokenType !== "cli" ||
+    !metadata.audience.includes("summer-cli")
+  ) {
+    throw new Error(
+      'The gateway returned a token that is not valid for the Summer CLI. Recovery: run "summer login --force" again after the gateway is updated.'
+    );
+  }
+  if (metadata.expiresAt && Date.parse(metadata.expiresAt) <= Date.now()) {
+    throw new Error(
+      'The gateway returned an expired CLI token. Recovery: run "summer login --force" again; if it repeats, check the gateway clock and token issuer.'
+    );
+  }
+  // Keep auth-token and user.json canonical: the desktop engine already reads
+  // those exact files. credential-metadata.json adds audience/scope information
+  // without changing or duplicating the secret.
+  // Activate the new auth token last. The desktop engine cross-checks token.sub
+  // against user.json, so an interrupted multi-file write fails closed instead
+  // of adopting a mismatched identity.
+  if (session.user) await saveUserInfo(session.user);
+  if (session.cloudToken) {
+    await saveCloudToken(session.cloudToken, session.cloudScopes);
+  }
+  await saveAuthToken(session.token, session.scopes);
 }
 
-export async function saveUserInfo(info: {
-  id: string;
-  email: string;
-  name?: string;
-}): Promise<void> {
-  await ensureSummerDir();
-  await writeFile(join(SUMMER_DIR, "user.json"), JSON.stringify(info, null, 2), { encoding: "utf-8", mode: 0o600 });
+export async function getCredentialMetadata(): Promise<CredentialMetadataDocument> {
+  const metadata = await readMetadata();
+  const token = await getAuthToken();
+  const cloudToken = await getCloudToken();
+  const creatorToken = await getCreatorToken();
+  return {
+    schemaVersion: 1,
+    ...(token
+      ? { auth: metadata.auth ?? decodeJwtMetadata(token) }
+      : {}),
+    ...(cloudToken
+      ? { cloud: metadata.cloud ?? decodeJwtMetadata(cloudToken) }
+      : {}),
+    ...(creatorToken
+      ? {
+          creator: metadata.creator ?? {
+            audience: ["summercraft-creator"],
+            scopes: [],
+            tokenType: "api",
+          },
+        }
+      : {}),
+  };
+}
+
+export async function clearAuthCredentials(): Promise<number> {
+  let removed = 0;
+  for (const file of [
+    AUTH_TOKEN_FILE,
+    CLOUD_TOKEN_FILE,
+    CREATOR_TOKEN_FILE,
+    USER_FILE,
+    METADATA_FILE,
+  ]) {
+    if (await removeStoreFile(file)) removed += 1;
+  }
+  return removed;
+}
+
+export function assertCredentialScopes(
+  metadata: CredentialMetadata | undefined,
+  requiredScopes: string[]
+): void {
+  const missing = requiredScopes.filter(
+    (scope) => !metadata?.scopes.includes(scope)
+  );
+  if (missing.length === 0) return;
+  throw new Error(
+    `This sign-in does not grant ${missing.join(", ")}. Recovery: run "summer login --force" after the platform enables scoped creator tokens, then retry.`
+  );
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,184 @@
+import { readStoreJson, writeStoreJson } from "./store.js";
+
+const CONFIG_FILE = "config.json";
+const DEFAULT_GATEWAY_URL = "https://www.summerengine.com";
+const DEFAULT_CREATOR_API_URL = "https://summercraft.ai";
+
+export interface SummerConfig {
+  schemaVersion: 1;
+  gateway?: {
+    url?: string;
+  };
+  creator?: {
+    apiUrl?: string;
+    projectId?: string;
+    channel?: string;
+  };
+}
+
+export const CONFIG_KEYS = [
+  "gateway.url",
+  "creator.apiUrl",
+  "creator.projectId",
+  "creator.channel",
+] as const;
+
+export type ConfigKey = (typeof CONFIG_KEYS)[number];
+
+function emptyConfig(): SummerConfig {
+  return { schemaVersion: 1 };
+}
+
+export async function readSummerConfig(): Promise<SummerConfig> {
+  const value = await readStoreJson<SummerConfig>(CONFIG_FILE);
+  if (!value) return emptyConfig();
+  if (value.schemaVersion !== 1) {
+    throw new Error(
+      `Unsupported ~/.summer/config.json schema ${String(value.schemaVersion)}. Recovery: upgrade the Summer CLI, or move config.json aside and configure it again.`
+    );
+  }
+  return value;
+}
+
+function validateGatewayUrl(value: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(
+      `gateway.url must be a complete URL. Recovery: use "summer config set gateway.url https://www.summerengine.com".`
+    );
+  }
+  const local =
+    parsed.hostname === "localhost" ||
+    parsed.hostname === "127.0.0.1" ||
+    parsed.hostname === "::1";
+  if (parsed.protocol !== "https:" && !(local && parsed.protocol === "http:")) {
+    throw new Error(
+      "gateway.url must use HTTPS (HTTP is allowed only for localhost). Recovery: set an HTTPS URL and retry."
+    );
+  }
+  if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+    throw new Error(
+      "gateway.url cannot contain credentials, query parameters, or fragments. Recovery: set only the origin URL and retry."
+    );
+  }
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+function validateCreatorApiUrl(value: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(
+      'creator.apiUrl must be a complete URL. Recovery: use "summer config set creator.apiUrl https://summercraft.ai".'
+    );
+  }
+  const local =
+    parsed.hostname === "localhost" ||
+    parsed.hostname === "127.0.0.1" ||
+    parsed.hostname === "::1";
+  if (parsed.protocol !== "https:" && !(local && parsed.protocol === "http:")) {
+    throw new Error(
+      "creator.apiUrl must use HTTPS (HTTP is allowed only for localhost). Recovery: set an HTTPS URL and retry."
+    );
+  }
+  if (
+    parsed.username ||
+    parsed.password ||
+    parsed.pathname !== "/" ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw new Error(
+      "creator.apiUrl must be an origin without credentials, a path, query parameters, or fragments."
+    );
+  }
+  return parsed.origin;
+}
+
+function validateValue(key: ConfigKey, value: string): string {
+  const clean = value.trim();
+  if (!clean) {
+    throw new Error(
+      `Cannot set ${key} to an empty value. Recovery: provide a value, or run "summer config unset ${key}".`
+    );
+  }
+  if (key === "gateway.url") return validateGatewayUrl(clean);
+  if (key === "creator.apiUrl") return validateCreatorApiUrl(clean);
+  if (key === "creator.channel" && !/^[a-z0-9][a-z0-9._-]{0,63}$/i.test(clean)) {
+    throw new Error(
+      "creator.channel may contain letters, numbers, dots, underscores, and hyphens. Recovery: choose a channel such as production or preview."
+    );
+  }
+  if (key === "creator.projectId" && clean.length > 128) {
+    throw new Error(
+      "creator.projectId is too long. Recovery: copy the project ID from the Summer creator dashboard and retry."
+    );
+  }
+  return clean;
+}
+
+export function getConfigValue(
+  config: SummerConfig,
+  key: ConfigKey
+): string | undefined {
+  if (key === "gateway.url") return config.gateway?.url;
+  if (key === "creator.apiUrl") return config.creator?.apiUrl;
+  if (key === "creator.projectId") return config.creator?.projectId;
+  return config.creator?.channel;
+}
+
+export async function setConfigValue(
+  key: ConfigKey,
+  rawValue: string
+): Promise<SummerConfig> {
+  const config = await readSummerConfig();
+  const value = validateValue(key, rawValue);
+  if (key === "gateway.url") {
+    config.gateway = { ...config.gateway, url: value };
+  } else if (key === "creator.apiUrl") {
+    config.creator = { ...config.creator, apiUrl: value };
+  } else if (key === "creator.projectId") {
+    config.creator = { ...config.creator, projectId: value };
+  } else {
+    config.creator = { ...config.creator, channel: value };
+  }
+  await writeStoreJson(CONFIG_FILE, config);
+  return config;
+}
+
+export async function unsetConfigValue(key: ConfigKey): Promise<SummerConfig> {
+  const config = await readSummerConfig();
+  if (key === "gateway.url" && config.gateway) delete config.gateway.url;
+  if (key === "creator.apiUrl" && config.creator) delete config.creator.apiUrl;
+  if (key === "creator.projectId" && config.creator) {
+    delete config.creator.projectId;
+  }
+  if (key === "creator.channel" && config.creator) delete config.creator.channel;
+  if (config.gateway && Object.keys(config.gateway).length === 0) {
+    delete config.gateway;
+  }
+  if (config.creator && Object.keys(config.creator).length === 0) {
+    delete config.creator;
+  }
+  await writeStoreJson(CONFIG_FILE, config);
+  return config;
+}
+
+export function isConfigKey(value: string): value is ConfigKey {
+  return (CONFIG_KEYS as readonly string[]).includes(value);
+}
+
+export async function getGatewayUrl(): Promise<string> {
+  const environment = process.env.SUMMER_GATEWAY_URL?.trim();
+  if (environment) return validateGatewayUrl(environment);
+  const config = await readSummerConfig();
+  return config.gateway?.url ?? DEFAULT_GATEWAY_URL;
+}
+
+export async function getCreatorApiUrl(): Promise<string> {
+  const config = await readSummerConfig();
+  return config.creator?.apiUrl ?? DEFAULT_CREATOR_API_URL;
+}

--- a/src/lib/creator.test.ts
+++ b/src/lib/creator.test.ts
@@ -1,0 +1,337 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { saveCreatorToken } from "./auth.js";
+import { setConfigValue } from "./config.js";
+import {
+  CREATOR_API_CONTRACT,
+  CreatorOperationError,
+  listCreatorReleases,
+  publishCreator,
+  readCreatorLogs,
+} from "./creator.js";
+import { setSummerDirForTests } from "./store.js";
+
+const GAME_ID = "11111111-1111-4111-8111-111111111111";
+const RELEASE_ID = "22222222-2222-4222-8222-222222222222";
+const CREATOR_TOKEN = `sc_${"a".repeat(43)}`;
+
+let root = "";
+let artifact = "";
+let artifactBytes: Buffer;
+let sha256 = "";
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "summer-creator-test-"));
+  artifact = join(root, "release.pck");
+  artifactBytes = Buffer.from("Summer PCK fixture".padEnd(2048, "."));
+  sha256 = createHash("sha256").update(artifactBytes).digest("hex");
+  await writeFile(artifact, artifactBytes);
+  setSummerDirForTests(join(root, ".summer"));
+  await setConfigValue("creator.apiUrl", "http://localhost:3000");
+  await setConfigValue("creator.projectId", GAME_ID);
+  await saveCreatorToken(CREATOR_TOKEN);
+});
+
+afterEach(async () => {
+  setSummerDirForTests(null);
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  await rm(root, { recursive: true, force: true });
+});
+
+function jsonResponse(value: unknown, status = 200) {
+  return Response.json(value, { status });
+}
+
+function publishFetch() {
+  let call = 0;
+  return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    call += 1;
+    const url = String(input);
+    if (call === 1) {
+      expect(url).toBe("http://localhost:3000/api/creator/v1/publish");
+      expect((init?.headers as Record<string, string>).authorization).toBe(
+        `Bearer ${CREATOR_TOKEN}`
+      );
+      const body = JSON.parse(String(init?.body));
+      expect(body).toMatchObject({
+        contract: CREATOR_API_CONTRACT,
+        operation: "prepare",
+        gameId: GAME_ID,
+        version: "1.0.0",
+        sha256,
+        sizeBytes: artifactBytes.byteLength,
+        confirmation: {
+          gameId: GAME_ID,
+          version: "1.0.0",
+          sha256,
+        },
+      });
+      return jsonResponse({
+        contract: CREATOR_API_CONTRACT,
+        operation: "prepare",
+        uploadUrl: "http://localhost:4000/immutable-upload",
+        headers: {
+          "content-type": "application/octet-stream",
+          "if-none-match": "*",
+        },
+        method: "PUT",
+        finalizeUrl: "/api/creator/v1/publish",
+      });
+    }
+    if (call === 2) {
+      expect(url).toBe("http://localhost:4000/immutable-upload");
+      expect(init?.method).toBe("PUT");
+      expect(init?.headers).toEqual({
+        "content-type": "application/octet-stream",
+        "if-none-match": "*",
+      });
+      const chunks: Buffer[] = [];
+      for await (const chunk of init?.body as AsyncIterable<Buffer>) {
+        chunks.push(Buffer.from(chunk));
+      }
+      expect(Buffer.concat(chunks)).toEqual(artifactBytes);
+      return new Response(null, { status: 200 });
+    }
+    expect(url).toBe("http://localhost:3000/api/creator/v1/publish");
+    const body = JSON.parse(String(init?.body));
+    expect(body.operation).toBe("finalize");
+    expect(body.confirmation).toEqual({
+      gameId: GAME_ID,
+      version: "1.0.0",
+      sha256,
+    });
+    return jsonResponse(
+      {
+        contract: CREATOR_API_CONTRACT,
+        operation: "finalize",
+        releaseId: RELEASE_ID,
+        gameId: GAME_ID,
+        version: "1.0.0",
+        sha256,
+        sizeBytes: artifactBytes.byteLength,
+        status: "pending_review",
+        detail: "Release recorded and queued for review.",
+      },
+      201
+    );
+  });
+}
+
+describe("versioned creator API client", () => {
+  it("computes and records the exact target before confirmation", async () => {
+    const fetchMock = vi.fn();
+    await expect(
+      publishCreator(
+        {
+          project: root,
+          artifact,
+          version: "1.0.0",
+          face: "cli",
+          confirm: false,
+        },
+        { fetch: fetchMock as typeof fetch }
+      )
+    ).rejects.toMatchObject({
+      code: "publish_confirmation_required",
+      operation: "publish",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    const audit = await readFile(
+      join(root, ".summer", "creator-audit.jsonl"),
+      "utf8"
+    );
+    expect(JSON.parse(audit.trim())).toMatchObject({
+      operation: "publish",
+      outcome: "confirmation_required",
+      projectId: GAME_ID,
+      artifact,
+      version: "1.0.0",
+      sha256,
+      sizeBytes: artifactBytes.byteLength,
+    });
+  });
+
+  it("runs prepare → signed immutable PUT → finalize and audits success", async () => {
+    const fetchMock = publishFetch();
+    const result = await publishCreator(
+      {
+        project: root,
+        artifact,
+        version: "1.0.0",
+        notes: "First release",
+        face: "cli",
+        confirm: true,
+      },
+      {
+        fetch: fetchMock as typeof fetch,
+        now: () => new Date("2026-07-30T12:00:00.000Z"),
+      }
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({
+      ok: true,
+      contract: CREATOR_API_CONTRACT,
+      operation: "publish",
+      projectId: GAME_ID,
+      releaseId: RELEASE_ID,
+      version: "1.0.0",
+      sha256,
+      sizeBytes: artifactBytes.byteLength,
+      status: "pending_review",
+      detail: "Release recorded and queued for review.",
+    });
+    const audit = (
+      await readFile(join(root, ".summer", "creator-audit.jsonl"), "utf8")
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(audit.map((entry) => entry.outcome)).toEqual([
+      "started",
+      "succeeded",
+    ]);
+    expect(JSON.stringify(audit)).not.toContain(CREATOR_TOKEN);
+  });
+
+  it("treats local scope metadata as advisory and server refusal as authoritative", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(
+        {
+          contract: CREATOR_API_CONTRACT,
+          error: "sign_in_required",
+          detail: "A publish-scoped token is required.",
+          recovery: "Mint an exact publish-scoped token and retry.",
+        },
+        401
+      )
+    );
+    await expect(
+      publishCreator(
+        {
+          project: root,
+          artifact,
+          version: "1.0.0",
+          face: "cli",
+          confirm: true,
+        },
+        { fetch: fetchMock as typeof fetch }
+      )
+    ).rejects.toMatchObject({
+      code: "sign_in_required",
+      operation: "publish",
+      status: 401,
+    });
+  });
+
+  it("returns real creator-owned release history with its opaque cursor", async () => {
+    const fetchMock = vi.fn(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(String(input));
+        expect(url.pathname).toBe("/api/creator/v1/releases");
+        expect(url.searchParams.get("gameId")).toBe(GAME_ID);
+        expect(url.searchParams.get("limit")).toBe("10");
+        expect(url.searchParams.get("cursor")).toBe("cursor-1");
+        expect((init?.headers as Record<string, string>).authorization).toBe(
+          `Bearer ${CREATOR_TOKEN}`
+        );
+        return jsonResponse({
+          contract: CREATOR_API_CONTRACT,
+          gameId: GAME_ID,
+          releases: [
+            {
+              releaseId: RELEASE_ID,
+              gameId: GAME_ID,
+              version: "1.0.0",
+              state: "pending_review",
+              gameStatus: "review",
+              sha256,
+              sizeBytes: artifactBytes.byteLength,
+              changelog: null,
+              submittedAt: "2026-07-30T12:00:00.000Z",
+              artifactPlane: "r2",
+            },
+          ],
+          nextCursor: "cursor-2",
+        });
+      }
+    );
+    const result = await listCreatorReleases(
+      { face: "cli", limit: 10, cursor: "cursor-1" },
+      { fetch: fetchMock as typeof fetch }
+    );
+    expect(result.releases[0]).toMatchObject({
+      releaseId: RELEASE_ID,
+      state: "pending_review",
+      sha256,
+    });
+    expect(result.nextCursor).toBe("cursor-2");
+  });
+
+  it("keeps logs explicitly unsupported without returning placeholders", async () => {
+    await expect(readCreatorLogs({ face: "cli" })).rejects.toMatchObject({
+      code: "creator_backend_unavailable",
+      operation: "logs",
+    });
+  });
+
+  it("refuses unsafe prepare headers before uploading bytes", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        contract: CREATOR_API_CONTRACT,
+        operation: "prepare",
+        uploadUrl: "https://uploads.example/object",
+        headers: { "content-type": "application/octet-stream" },
+        method: "PUT",
+        finalizeUrl: "/api/creator/v1/publish",
+      })
+    );
+    await expect(
+      publishCreator(
+        {
+          project: root,
+          artifact,
+          version: "1.0.0",
+          face: "cli",
+          confirm: true,
+        },
+        { fetch: fetchMock as typeof fetch }
+      )
+    ).rejects.toMatchObject({
+      code: "creator_unsafe_upload_headers",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("creator input boundaries", () => {
+  it("requires an explicit immutable artifact and version", async () => {
+    await expect(
+      publishCreator({ project: root, face: "cli", confirm: false })
+    ).rejects.toThrow(/version is required/);
+    await expect(
+      publishCreator({
+        project: root,
+        version: "1.0.0",
+        face: "cli",
+        confirm: false,
+      })
+    ).rejects.toThrow(/artifact is required/);
+  });
+
+  it("uses typed creator operation errors for server failures", () => {
+    expect(
+      new CreatorOperationError(
+        "code",
+        "publish",
+        "message",
+        "recovery",
+        409
+      )
+    ).toMatchObject({ code: "code", operation: "publish", status: 409 });
+  });
+});

--- a/src/lib/creator.ts
+++ b/src/lib/creator.ts
@@ -1,0 +1,701 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { lstat, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import {
+  getCredentialMetadata,
+  getCreatorToken,
+} from "./auth.js";
+import {
+  getCreatorApiUrl,
+  readSummerConfig,
+} from "./config.js";
+import { appendStoreJsonLine } from "./store.js";
+
+export type CreatorOperation = "publish" | "releases" | "logs";
+export type CreatorFace = "cli" | "mcp";
+
+export const CREATOR_API_CONTRACT = "summer.creator.v1" as const;
+const CREATOR_PUBLISH_PATH = "/api/creator/v1/publish";
+const CREATOR_RELEASES_PATH = "/api/creator/v1/releases";
+const REQUIRED_SCOPE = "publish";
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const VERSION = /^[A-Za-z0-9][A-Za-z0-9._-]{0,31}$/;
+
+export const CREATOR_API_AUDIT = {
+  auditedAt: "2026-07-30",
+  repository: "SummerEngine/summercraft",
+  contract: CREATOR_API_CONTRACT,
+  credentialAudience: "summercraft-creator",
+  requiredServerScope: REQUIRED_SCOPE,
+  operations: {
+    publish: { supported: true, route: CREATOR_PUBLISH_PATH },
+    releases: { supported: true, route: CREATOR_RELEASES_PATH },
+    logs: { supported: false, route: null },
+  },
+} as const;
+
+const LOGS_RECOVERY =
+  "Recovery: Summercraft must first own a durable runtime-log source with retention, redaction, project/release authorization, and a versioned query route. No placeholder logs were returned.";
+
+export class CreatorOperationError extends Error {
+  constructor(
+    readonly code: string,
+    readonly operation: CreatorOperation,
+    message: string,
+    readonly recovery: string,
+    readonly status?: number
+  ) {
+    super(`${message} ${recovery}`);
+    this.name = "CreatorOperationError";
+  }
+}
+
+export interface CreatorClientDependencies {
+  fetch: typeof fetch;
+  now: () => Date;
+}
+
+const defaultDependencies: CreatorClientDependencies = {
+  fetch: (input, init) => globalThis.fetch(input, init),
+  now: () => new Date(),
+};
+
+async function resolveProjectId(explicit?: string): Promise<string> {
+  const projectId =
+    explicit?.trim() || (await readSummerConfig()).creator?.projectId;
+  if (!projectId) {
+    throw new Error(
+      'No creator project is selected. Recovery: pass --project-id <uuid>, or run "summer config set creator.projectId <uuid>".'
+    );
+  }
+  if (!UUID.test(projectId)) {
+    throw new Error(
+      `Creator project ID "${projectId}" is not a UUID. Recovery: copy the Summer game ID from the creator dashboard and configure it again.`
+    );
+  }
+  return projectId;
+}
+
+async function requireCreatorCredential(
+  operation: "publish" | "releases"
+): Promise<string> {
+  const token = await getCreatorToken();
+  if (!token) {
+    throw new CreatorOperationError(
+      "creator_token_required",
+      operation,
+      "Creator publishing needs a separate Summercraft API token.",
+      'Recovery: run "summer login --creator", mint a token with the exact "publish" scope in the opened browser page, and paste its one-time sc_ value. Your core Summer login will not be changed.'
+    );
+  }
+  const metadata = await getCredentialMetadata();
+  if (!metadata.creator?.scopes.includes(REQUIRED_SCOPE)) {
+    throw new CreatorOperationError(
+      "creator_scope_missing",
+      operation,
+      `The locally recorded creator credential does not declare the exact "${REQUIRED_SCOPE}" scope.`,
+      'Recovery: run "summer login --creator --force", mint a new publish-scoped token, and retry. The server will still independently verify the scope.'
+    );
+  }
+  return token;
+}
+
+function recoveryForStatus(operation: CreatorOperation, status: number): string {
+  if (status === 401 || status === 403) {
+    return 'Recovery: run "summer login --creator --force", mint a non-revoked token with the exact "publish" scope, and retry.';
+  }
+  if (status === 404) {
+    return 'Recovery: check creator.projectId against the Summer creator dashboard and make sure that game belongs to the token owner.';
+  }
+  if (status === 409 && operation === "publish") {
+    return "Recovery: read the server detail, bump an immutable version when required, then repeat the unconfirmed command to review the new exact target.";
+  }
+  return `Recovery: retry once; if it repeats, check creator.apiUrl and the Summercraft creator API health.`;
+}
+
+async function readJsonResponse(
+  response: Response,
+  operation: CreatorOperation
+): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    throw new CreatorOperationError(
+      "creator_invalid_response",
+      operation,
+      `The creator API returned a non-JSON response (${response.status}).`,
+      recoveryForStatus(operation, response.status),
+      response.status
+    );
+  }
+  if (!response.ok) {
+    const code =
+      typeof payload.error === "string" ? payload.error : "creator_request_failed";
+    const detail =
+      typeof payload.detail === "string"
+        ? payload.detail
+        : `The creator API refused the request (${response.status}).`;
+    const recovery =
+      typeof payload.recovery === "string"
+        ? payload.recovery
+        : recoveryForStatus(operation, response.status);
+    throw new CreatorOperationError(
+      code,
+      operation,
+      detail,
+      recovery,
+      response.status
+    );
+  }
+  if (payload.contract !== CREATOR_API_CONTRACT) {
+    throw new CreatorOperationError(
+      "creator_contract_mismatch",
+      operation,
+      `The creator API did not return contract ${CREATOR_API_CONTRACT}.`,
+      "Recovery: upgrade the Summer CLI and retry; if it repeats, the configured creator API is incompatible.",
+      response.status
+    );
+  }
+  return payload;
+}
+
+async function creatorRequest(
+  operation: CreatorOperation,
+  path: string,
+  token: string,
+  deps: CreatorClientDependencies,
+  init: RequestInit = {}
+): Promise<Record<string, unknown>> {
+  let response: Response;
+  try {
+    response = await deps.fetch(`${await getCreatorApiUrl()}${path}`, {
+      ...init,
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${token}`,
+        ...(init.body ? { "content-type": "application/json" } : {}),
+        ...init.headers,
+      },
+      signal: AbortSignal.timeout(operation === "publish" ? 300_000 : 30_000),
+    });
+  } catch (error) {
+    throw new CreatorOperationError(
+      "creator_network_failed",
+      operation,
+      `The creator API request failed: ${
+        error instanceof Error ? error.message : String(error)
+      }.`,
+      "Recovery: check your network and creator.apiUrl, then retry. No successful release is being claimed."
+    );
+  }
+  return readJsonResponse(response, operation);
+}
+
+async function inspectArtifact(path: string): Promise<{
+  path: string;
+  sizeBytes: number;
+  sha256: string;
+}> {
+  const artifactPath = resolve(path);
+  const info = await lstat(artifactPath).catch(() => null);
+  if (!info || !info.isFile() || info.isSymbolicLink()) {
+    throw new Error(
+      `Release artifact ${artifactPath} must be a real regular file, not a missing path, directory, or symlink.`
+    );
+  }
+  if (!artifactPath.toLowerCase().endsWith(".pck")) {
+    throw new Error(
+      `Release artifact ${artifactPath} is not a .pck. Recovery: export a Summer PCK and pass its exact path with --artifact.`
+    );
+  }
+  if (info.size <= 0) {
+    throw new Error(
+      `Release artifact ${artifactPath} is empty. Recovery: export the Summer PCK again and verify it locally before publishing.`
+    );
+  }
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(artifactPath)) hash.update(chunk);
+  return {
+    path: artifactPath,
+    sizeBytes: info.size,
+    sha256: hash.digest("hex"),
+  };
+}
+
+async function readManifest(path?: string): Promise<unknown | undefined> {
+  if (!path) return undefined;
+  const manifestPath = resolve(path);
+  try {
+    return JSON.parse(await readFile(manifestPath, "utf8")) as unknown;
+  } catch (error) {
+    throw new Error(
+      `Cannot read release manifest ${manifestPath}: ${
+        error instanceof Error ? error.message : String(error)
+      }. Recovery: pass a valid JSON manifest or omit --manifest.`
+    );
+  }
+}
+
+function assertUploadUrl(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new CreatorOperationError(
+      "creator_invalid_response",
+      "publish",
+      "The prepare response did not contain an uploadUrl.",
+      "Recovery: retry once; if it repeats, report the Summercraft creator API as unhealthy."
+    );
+  }
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new CreatorOperationError(
+      "creator_unsafe_upload_url",
+      "publish",
+      "The creator API returned a malformed upload URL.",
+      "Recovery: do not upload the artifact; report the creator API response as a security issue."
+    );
+  }
+  const local =
+    url.hostname === "localhost" ||
+    url.hostname === "127.0.0.1" ||
+    url.hostname === "::1";
+  if (
+    url.username ||
+    url.password ||
+    (url.protocol !== "https:" && !(local && url.protocol === "http:"))
+  ) {
+    throw new CreatorOperationError(
+      "creator_unsafe_upload_url",
+      "publish",
+      "The creator API returned an unsafe upload URL.",
+      "Recovery: do not upload the artifact; report the creator API response as a security issue."
+    );
+  }
+  return url.toString();
+}
+
+function assertUploadHeaders(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new CreatorOperationError(
+      "creator_invalid_response",
+      "publish",
+      "The prepare response did not contain signed upload headers.",
+      "Recovery: retry once; if it repeats, report the Summercraft creator API as unhealthy."
+    );
+  }
+  const headers = Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string"
+    )
+  );
+  if (
+    headers["content-type"] !== "application/octet-stream" ||
+    headers["if-none-match"] !== "*"
+  ) {
+    throw new CreatorOperationError(
+      "creator_unsafe_upload_headers",
+      "publish",
+      "The prepare response did not bind the expected content type and write-once header.",
+      "Recovery: do not upload the artifact; report the creator API response as a security issue."
+    );
+  }
+  return headers;
+}
+
+async function uploadArtifact(
+  uploadUrl: string,
+  headers: Record<string, string>,
+  artifactPath: string,
+  deps: CreatorClientDependencies
+): Promise<void> {
+  let response: Response;
+  try {
+    response = await deps.fetch(uploadUrl, {
+      method: "PUT",
+      headers,
+      body: createReadStream(artifactPath) as unknown as BodyInit,
+      // Node fetch requires this for a streaming request body. It is a Node
+      // extension and therefore absent from the DOM RequestInit declaration.
+      duplex: "half",
+      signal: AbortSignal.timeout(600_000),
+    } as RequestInit & { duplex: "half" });
+  } catch (error) {
+    throw new CreatorOperationError(
+      "creator_upload_failed",
+      "publish",
+      `The artifact upload failed: ${
+        error instanceof Error ? error.message : String(error)
+      }.`,
+      "Recovery: rerun the unconfirmed publish command to recompute and review the exact artifact, then retry."
+    );
+  }
+  if (!response.ok) {
+    throw new CreatorOperationError(
+      "creator_upload_refused",
+      "publish",
+      `The immutable artifact upload was refused (${response.status}).`,
+      response.status === 412
+        ? "Recovery: the content-addressed key is already occupied. Do not overwrite it; verify the project/version and retry with a new immutable version."
+        : "Recovery: repeat prepare and reproduce every returned signed header exactly, then retry.",
+      response.status
+    );
+  }
+}
+
+export interface PublishCreatorInput {
+  project?: string;
+  artifact?: string;
+  manifest?: string;
+  version?: string;
+  projectId?: string;
+  channel?: string;
+  notes?: string;
+  confirm?: boolean;
+  face: CreatorFace;
+}
+
+export interface CreatorPublishResult {
+  ok: true;
+  contract: typeof CREATOR_API_CONTRACT;
+  operation: "publish";
+  projectId: string;
+  releaseId: string;
+  version: string;
+  sha256: string;
+  sizeBytes: number;
+  status: string;
+  detail: string | null;
+}
+
+export async function publishCreator(
+  input: PublishCreatorInput,
+  overrides: Partial<CreatorClientDependencies> = {}
+): Promise<CreatorPublishResult> {
+  const deps = { ...defaultDependencies, ...overrides };
+  const project = resolve(input.project ?? process.cwd());
+  const projectId = await resolveProjectId(input.projectId);
+  const channel =
+    input.channel?.trim() ||
+    (await readSummerConfig()).creator?.channel ||
+    "production";
+  if (channel !== "production") {
+    throw new CreatorOperationError(
+      "creator_channel_unsupported",
+      "publish",
+      `The Summercraft creator API has no "${channel}" release channel.`,
+      'Recovery: use --channel production or run "summer config set creator.channel production". No release was created.'
+    );
+  }
+  const version = input.version?.trim();
+  if (!version || !VERSION.test(version)) {
+    throw new Error(
+      "A release version is required and must be 1–32 characters of letters, numbers, dots, underscores, or hyphens. Recovery: pass --version <value>."
+    );
+  }
+  if (!input.artifact) {
+    throw new Error(
+      "A release artifact is required. Recovery: export a Summer .pck and pass --artifact <path>; the CLI never guesses an export layout."
+    );
+  }
+  const artifact = await inspectArtifact(input.artifact);
+  const manifest = await readManifest(input.manifest);
+  const auditBase = {
+    at: deps.now().toISOString(),
+    operation: "publish",
+    face: input.face,
+    project,
+    projectId,
+    channel,
+    artifact: artifact.path,
+    version,
+    sha256: artifact.sha256,
+    sizeBytes: artifact.sizeBytes,
+    notes: input.notes?.trim() || null,
+  };
+
+  if (!input.confirm) {
+    await appendStoreJsonLine("creator-audit.jsonl", {
+      ...auditBase,
+      outcome: "confirmation_required",
+    });
+    throw new CreatorOperationError(
+      "publish_confirmation_required",
+      "publish",
+      `Publishing changes project ${projectId}: version ${version}, sha256 ${artifact.sha256}, ${artifact.sizeBytes} bytes from ${artifact.path}.`,
+      "Recovery: show this exact project, version, digest, size, and artifact path to the user. Only after approval, rerun with --confirm (or confirm=true). No release was created."
+    );
+  }
+
+  let token: string;
+  try {
+    token = await requireCreatorCredential("publish");
+    await appendStoreJsonLine("creator-audit.jsonl", {
+      ...auditBase,
+      outcome: "started",
+      tokenAudience: "summercraft-creator",
+      advisoryTokenScopes: [REQUIRED_SCOPE],
+    });
+
+    const confirmation = {
+      gameId: projectId,
+      version,
+      sha256: artifact.sha256,
+    };
+    const prepareBody = {
+      contract: CREATOR_API_CONTRACT,
+      operation: "prepare",
+      ...confirmation,
+      sizeBytes: artifact.sizeBytes,
+      contentType: "application/octet-stream",
+      ...(input.notes?.trim() ? { changelog: input.notes.trim() } : {}),
+      ...(manifest !== undefined ? { manifest } : {}),
+      confirmation,
+    };
+    const prepared = await creatorRequest(
+      "publish",
+      CREATOR_PUBLISH_PATH,
+      token,
+      deps,
+      {
+        method: "POST",
+        body: JSON.stringify(prepareBody),
+      }
+    );
+    if (prepared.operation !== "prepare") {
+      throw new CreatorOperationError(
+        "creator_invalid_response",
+        "publish",
+        "The prepare response named the wrong operation.",
+        "Recovery: do not upload the artifact; upgrade the Summer CLI or report the creator API as incompatible."
+      );
+    }
+    if (
+      prepared.method !== "PUT" ||
+      prepared.finalizeUrl !== CREATOR_PUBLISH_PATH
+    ) {
+      throw new CreatorOperationError(
+        "creator_invalid_response",
+        "publish",
+        "The prepare response did not bind the expected PUT and versioned finalize route.",
+        "Recovery: do not upload the artifact; upgrade the Summer CLI or report the creator API as incompatible."
+      );
+    }
+    await uploadArtifact(
+      assertUploadUrl(prepared.uploadUrl),
+      assertUploadHeaders(prepared.headers),
+      artifact.path,
+      deps
+    );
+
+    const finalized = await creatorRequest(
+      "publish",
+      CREATOR_PUBLISH_PATH,
+      token,
+      deps,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          ...prepareBody,
+          operation: "finalize",
+        }),
+      }
+    );
+    if (
+      finalized.operation !== "finalize" ||
+      typeof finalized.releaseId !== "string" ||
+      !UUID.test(finalized.releaseId) ||
+      finalized.status !== "pending_review" ||
+      finalized.gameId !== projectId ||
+      finalized.version !== version ||
+      finalized.sha256 !== artifact.sha256 ||
+      finalized.sizeBytes !== artifact.sizeBytes
+    ) {
+      throw new CreatorOperationError(
+        "creator_invalid_response",
+        "publish",
+        "The finalize response did not echo the exact project, version, digest, size, release ID, and status.",
+        "Recovery: query summer releases before retrying; the server may have recorded the release even though its response was incomplete."
+      );
+    }
+    const result: CreatorPublishResult = {
+      ok: true,
+      contract: CREATOR_API_CONTRACT,
+      operation: "publish",
+      projectId,
+      releaseId: finalized.releaseId,
+      version,
+      sha256: artifact.sha256,
+      sizeBytes: artifact.sizeBytes,
+      status: finalized.status,
+      detail:
+        typeof finalized.detail === "string" ? finalized.detail : null,
+    };
+    await appendStoreJsonLine("creator-audit.jsonl", {
+      ...auditBase,
+      outcome: "succeeded",
+      releaseId: result.releaseId,
+      releaseStatus: result.status,
+    });
+    return result;
+  } catch (error) {
+    await appendStoreJsonLine("creator-audit.jsonl", {
+      ...auditBase,
+      outcome: "failed",
+      code:
+        error instanceof CreatorOperationError
+          ? error.code
+          : "creator_request_invalid",
+      status:
+        error instanceof CreatorOperationError ? error.status ?? null : null,
+    });
+    throw error;
+  }
+}
+
+export interface ListCreatorReleasesInput {
+  projectId?: string;
+  limit?: number;
+  cursor?: string;
+  face: CreatorFace;
+}
+
+export interface CreatorRelease {
+  releaseId: string;
+  gameId: string;
+  version: string;
+  state: "published" | "pending_review" | "retired";
+  gameStatus: string;
+  sha256: string | null;
+  sizeBytes: number | null;
+  changelog: string | null;
+  submittedAt: string;
+  artifactPlane: "r2" | "legacy";
+}
+
+export interface CreatorReleasesResult {
+  ok: true;
+  contract: typeof CREATOR_API_CONTRACT;
+  operation: "releases";
+  projectId: string;
+  releases: CreatorRelease[];
+  nextCursor: string | null;
+}
+
+function readReleases(value: unknown, projectId: string): CreatorRelease[] {
+  if (!Array.isArray(value)) {
+    throw new CreatorOperationError(
+      "creator_invalid_response",
+      "releases",
+      "The creator API response did not contain a releases array.",
+      "Recovery: upgrade the Summer CLI and retry; if it repeats, report the creator API as incompatible."
+    );
+  }
+  const releases: CreatorRelease[] = [];
+  for (const item of value) {
+    const row = item as Partial<CreatorRelease> | null;
+    if (
+      !row ||
+      typeof row !== "object" ||
+      typeof row.releaseId !== "string" ||
+      !UUID.test(row.releaseId) ||
+      row.gameId !== projectId ||
+      typeof row.version !== "string" ||
+      !["published", "pending_review", "retired"].includes(
+        String(row.state)
+      ) ||
+      typeof row.gameStatus !== "string" ||
+      (row.sha256 !== null &&
+        (typeof row.sha256 !== "string" ||
+          !/^[0-9a-f]{64}$/.test(row.sha256))) ||
+      (row.sizeBytes !== null &&
+        (typeof row.sizeBytes !== "number" ||
+          !Number.isSafeInteger(row.sizeBytes) ||
+          row.sizeBytes < 0)) ||
+      (row.changelog !== null && typeof row.changelog !== "string") ||
+      typeof row.submittedAt !== "string" ||
+      !Number.isFinite(Date.parse(row.submittedAt)) ||
+      (row.artifactPlane !== "r2" && row.artifactPlane !== "legacy")
+    ) {
+      throw new CreatorOperationError(
+        "creator_invalid_response",
+        "releases",
+        "The creator API returned a malformed or cross-project release item.",
+        "Recovery: do not trust this release list; upgrade the Summer CLI or report the creator API as incompatible."
+      );
+    }
+    releases.push(row as CreatorRelease);
+  }
+  return releases;
+}
+
+export async function listCreatorReleases(
+  input: ListCreatorReleasesInput,
+  overrides: Partial<CreatorClientDependencies> = {}
+): Promise<CreatorReleasesResult> {
+  const deps = { ...defaultDependencies, ...overrides };
+  const projectId = await resolveProjectId(input.projectId);
+  const token = await requireCreatorCredential("releases");
+  const params = new URLSearchParams({
+    gameId: projectId,
+    limit: String(input.limit ?? 20),
+  });
+  if (input.cursor) params.set("cursor", input.cursor);
+  const payload = await creatorRequest(
+    "releases",
+    `${CREATOR_RELEASES_PATH}?${params}`,
+    token,
+    deps
+  );
+  if (payload.gameId !== projectId) {
+    throw new CreatorOperationError(
+      "creator_invalid_response",
+      "releases",
+      "The creator API returned release history for a different project.",
+      "Recovery: do not trust this release list; check creator.apiUrl and report the response as a security issue."
+    );
+  }
+  if (
+    payload.nextCursor !== null &&
+    typeof payload.nextCursor !== "string"
+  ) {
+    throw new CreatorOperationError(
+      "creator_invalid_response",
+      "releases",
+      "The creator API returned a malformed release cursor.",
+      "Recovery: omit the cursor and retry from the newest release; report the response if it repeats."
+    );
+  }
+  return {
+    ok: true,
+    contract: CREATOR_API_CONTRACT,
+    operation: "releases",
+    projectId,
+    releases: readReleases(payload.releases, projectId),
+    nextCursor: payload.nextCursor,
+  };
+}
+
+export interface ReadCreatorLogsInput {
+  projectId?: string;
+  releaseId?: string;
+  limit?: number;
+  face: CreatorFace;
+}
+
+export async function readCreatorLogs(
+  input: ReadCreatorLogsInput
+): Promise<never> {
+  await resolveProjectId(input.projectId);
+  throw new CreatorOperationError(
+    "creator_backend_unavailable",
+    "logs",
+    "Summercraft does not have a durable creator runtime-log API.",
+    LOGS_RECOVERY
+  );
+}

--- a/src/lib/public-product-language.test.ts
+++ b/src/lib/public-product-language.test.ts
@@ -1,0 +1,94 @@
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, extname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const PUBLIC_ROOTS = [
+  "README.md",
+  "AGENTS.md",
+  "GEMINI.md",
+  "docs",
+  "references",
+  "skills",
+  "tests/specs",
+  ".claude-plugin",
+  ".codex-plugin",
+  ".cursor-plugin",
+] as const;
+const TEXT_EXTENSIONS = new Set([".md", ".json", ".ts"]);
+
+async function publicTextFiles(path: string): Promise<string[]> {
+  const absolute = join(ROOT, path);
+  const entries = await readdir(absolute, { withFileTypes: true }).catch(() => []);
+  if (entries.length === 0) return [absolute];
+  const files: string[] = [];
+  for (const entry of entries) {
+    const child = join(absolute, entry.name);
+    if (entry.isDirectory()) files.push(...(await publicTextFiles(relative(ROOT, child))));
+    else if (TEXT_EXTENSIONS.has(extname(entry.name))) files.push(child);
+  }
+  return files;
+}
+
+describe("Summer-first public product language", () => {
+  it("does not regress to the stale fixed-4.5 or mirror copy", async () => {
+    const files = (
+      await Promise.all(PUBLIC_ROOTS.map((path) => publicTextFiles(path)))
+    ).flat();
+    const violations: string[] = [];
+    for (const file of files) {
+      const text = await readFile(file, "utf8");
+      if (/Godot 4\.5/i.test(text)) violations.push(`${relative(ROOT, file)}: fixed 4.5`);
+      if (/Engine mirror only/i.test(text)) violations.push(`${relative(ROOT, file)}: false mirror`);
+      if (/config\/features=PackedStringArray\("4\.5"\)/.test(text)) {
+        violations.push(`${relative(ROOT, file)}: stale project marker`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("keeps version policy in the technical compatibility note", async () => {
+    const note = await readFile(
+      join(ROOT, "references/godot-version.md"),
+      "utf8"
+    );
+    expect(note).toContain("Current Summer Engine base: **4.6.1**");
+    expect(note).toContain("Planned next base: **4.7.1**");
+    expect(note).toContain("follows upstream Godot continuously");
+    expect(note).toContain("Summer Engine is its own product and SDK");
+  });
+
+  it("keeps current distribution availability explicit", async () => {
+    const readme = await readFile(join(ROOT, "README.md"), "utf8");
+    expect(readme).toContain("macOS on Apple silicon and Windows");
+    expect(readme).toMatch(/planned\s+targets, not shipping promises/);
+    expect(readme).toContain("no supported public Linux installer");
+  });
+
+  it("keeps the public MCP total aligned with registered source tools", async () => {
+    const toolsDir = join(ROOT, "src/mcp/tools");
+    const toolFiles = (await readdir(toolsDir))
+      .filter((name) => name.endsWith("-tools.ts") && !name.endsWith(".test.ts"));
+    let registered = 0;
+    for (const file of toolFiles) {
+      const source = await readFile(join(toolsDir, file), "utf8");
+      registered += source.match(/\bserver\.tool\(/g)?.length ?? 0;
+    }
+    expect(registered).toBe(62);
+
+    for (const path of [
+      "README.md",
+      "AGENTS.md",
+      "GEMINI.md",
+      "references/mcp-tools-reference.md",
+      ".claude-plugin/plugin.json",
+      ".codex-plugin/plugin.json",
+      ".cursor-plugin/plugin.json",
+    ]) {
+      const text = await readFile(join(ROOT, path), "utf8");
+      expect(text, path).toMatch(/\b62(?: tools|-tool)/);
+      expect(text, path).not.toMatch(/\b(?:56|60)(?: tools|-tool)/);
+    }
+  });
+});

--- a/src/lib/public-product-language.test.ts
+++ b/src/lib/public-product-language.test.ts
@@ -61,9 +61,16 @@ describe("Summer-first public product language", () => {
 
   it("keeps current distribution availability explicit", async () => {
     const readme = await readFile(join(ROOT, "README.md"), "utf8");
+    const installer = await readFile(join(ROOT, "src/commands/install.ts"), "utf8");
     expect(readme).toContain("macOS on Apple silicon and Windows");
     expect(readme).toMatch(/planned\s+targets, not shipping promises/);
     expect(readme).toContain("no supported public Linux installer");
+    expect(installer).toContain("macOS on Apple silicon and Windows");
+    expect(installer).toContain("Linux does not have a supported public installer");
+    expect(installer).toContain("no manual Linux download is available");
+    expect(installer).not.toMatch(
+      /Linux support is coming soon\.[\s\S]{0,120}summerengine\.com\/download/
+    );
   });
 
   it("keeps the public MCP total aligned with registered source tools", async () => {

--- a/src/lib/store-auth-config.test.ts
+++ b/src/lib/store-auth-config.test.ts
@@ -1,0 +1,175 @@
+import { mkdtemp, readFile, rm, stat, symlink } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearAuthCredentials,
+  getAuthToken,
+  getCredentialMetadata,
+  getCreatorToken,
+  getUserInfo,
+  saveCreatorToken,
+  saveLoginSession,
+} from "./auth.js";
+import {
+  getConfigValue,
+  getGatewayUrl,
+  readSummerConfig,
+  setConfigValue,
+  unsetConfigValue,
+} from "./config.js";
+import {
+  readStoreText,
+  setSummerDirForTests,
+  writeStoreText,
+} from "./store.js";
+
+let root = "";
+const originalGateway = process.env.SUMMER_GATEWAY_URL;
+
+function token(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString(
+    "base64url"
+  );
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.test-signature`;
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "summer-store-test-"));
+  setSummerDirForTests(join(root, ".summer"));
+  delete process.env.SUMMER_GATEWAY_URL;
+});
+
+afterEach(async () => {
+  setSummerDirForTests(null);
+  if (originalGateway === undefined) delete process.env.SUMMER_GATEWAY_URL;
+  else process.env.SUMMER_GATEWAY_URL = originalGateway;
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("secure Summer store", () => {
+  it("uses hardened directory/file modes and refuses credential symlinks", async () => {
+    await writeStoreText("safe-token", "secret\n");
+    if (process.platform !== "win32") {
+      expect((await stat(join(root, ".summer"))).mode & 0o777).toBe(0o700);
+      expect((await stat(join(root, ".summer", "safe-token"))).mode & 0o777).toBe(
+        0o600
+      );
+    }
+
+    const outside = join(root, "outside");
+    await writeStoreText("outside", "not-used");
+    await rm(join(root, ".summer", "outside"));
+    await writeStoreText("target", "target");
+    await symlink(join(root, ".summer", "target"), outside);
+    await symlink(outside, join(root, ".summer", "unsafe-token"));
+
+    await expect(readStoreText("unsafe-token")).rejects.toMatchObject({
+      code: "unsafe_store_file",
+    });
+  });
+
+  it("keeps core-compatible auth files and records scope metadata without duplicating the secret", async () => {
+    const expires = Math.floor(Date.now() / 1000) + 3600;
+    const jwt = token({
+      sub: "user-1",
+      email: "maker@example.com",
+      type: "cli",
+      aud: "summer-cli",
+      iat: expires - 60,
+      exp: expires,
+    });
+
+    await saveLoginSession({
+      token: jwt,
+      user: {
+        id: "user-1",
+        email: "maker@example.com",
+      },
+      scopes: ["mcp:assets:read"],
+    });
+
+    expect(await getAuthToken()).toBe(jwt);
+    expect(await getUserInfo()).toEqual({
+      id: "user-1",
+      email: "maker@example.com",
+    });
+    expect(await getCredentialMetadata()).toMatchObject({
+      auth: {
+        audience: ["summer-cli"],
+        tokenType: "cli",
+        scopes: ["mcp:assets:read"],
+      },
+    });
+    const metadata = await readFile(
+      join(root, ".summer", "credential-metadata.json"),
+      "utf8"
+    );
+    expect(metadata).not.toContain(jwt);
+    await saveCreatorToken(`sc_${"a".repeat(43)}`);
+    expect(await getCreatorToken()).toBe(`sc_${"a".repeat(43)}`);
+    expect(await getAuthToken()).toBe(jwt);
+    expect(await getCredentialMetadata()).toMatchObject({
+      creator: {
+        audience: ["summercraft-creator"],
+        tokenType: "api",
+        scopes: ["publish"],
+      },
+    });
+    expect(
+      await readFile(join(root, ".summer", "credential-metadata.json"), "utf8")
+    ).not.toContain(`sc_${"a".repeat(43)}`);
+    expect(await clearAuthCredentials()).toBeGreaterThan(0);
+    expect(await getAuthToken()).toBeNull();
+    expect(await getCreatorToken()).toBeNull();
+  });
+
+  it("rejects a token/user identity mismatch before writing shared auth files", async () => {
+    await expect(
+      saveLoginSession({
+        token: token({
+          sub: "other-user",
+          type: "cli",
+          aud: "summer-cli",
+          exp: Math.floor(Date.now() / 1000) + 3600,
+        }),
+        user: { id: "user-1", email: "maker@example.com" },
+      })
+    ).rejects.toThrow(/mismatched identity/);
+    expect(await getAuthToken()).toBeNull();
+  });
+});
+
+describe("shared Summer config", () => {
+  it("sets, lists, unsets, and resolves non-secret configuration", async () => {
+    await setConfigValue("creator.projectId", "project-123");
+    await setConfigValue("creator.channel", "preview");
+    await setConfigValue("creator.apiUrl", "http://localhost:3000");
+    await setConfigValue("gateway.url", "https://gateway.example/");
+
+    const config = await readSummerConfig();
+    expect(getConfigValue(config, "creator.projectId")).toBe("project-123");
+    expect(getConfigValue(config, "creator.channel")).toBe("preview");
+    expect(getConfigValue(config, "creator.apiUrl")).toBe(
+      "http://localhost:3000"
+    );
+    expect(await getGatewayUrl()).toBe("https://gateway.example");
+
+    await unsetConfigValue("creator.channel");
+    expect(
+      getConfigValue(await readSummerConfig(), "creator.channel")
+    ).toBeUndefined();
+  });
+
+  it("allows local HTTP development but rejects insecure remote gateways", async () => {
+    await setConfigValue("gateway.url", "http://localhost:3000");
+    expect(await getGatewayUrl()).toBe("http://localhost:3000");
+    await expect(
+      setConfigValue("gateway.url", "http://gateway.example")
+    ).rejects.toThrow(/must use HTTPS/);
+    await expect(
+      setConfigValue("creator.apiUrl", "https://api.example/path")
+    ).rejects.toThrow(/must be an origin/);
+  });
+});

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,184 @@
+import {
+  appendFile,
+  chmod,
+  lstat,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+
+let summerDirOverride: string | null = null;
+
+export class SummerStoreError extends Error {
+  constructor(
+    readonly code: string,
+    message: string
+  ) {
+    super(message);
+    this.name = "SummerStoreError";
+  }
+}
+
+export function getSummerDir(): string {
+  return summerDirOverride ?? join(homedir(), ".summer");
+}
+
+/** Test-only seam. Passing null restores the real ~/.summer path. */
+export function setSummerDirForTests(path: string | null): void {
+  summerDirOverride = path;
+}
+
+function storePath(name: string): string {
+  if (!name || basename(name) !== name || name === "." || name === "..") {
+    throw new SummerStoreError(
+      "invalid_store_path",
+      `Invalid Summer store filename "${name}". Recovery: use a single filename inside ~/.summer/.`
+    );
+  }
+  return join(getSummerDir(), name);
+}
+
+async function hardenMode(path: string, mode: number): Promise<void> {
+  try {
+    await chmod(path, mode);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    // Windows does not implement POSIX permission bits consistently.
+    if (process.platform !== "win32" && code !== "EPERM") throw error;
+  }
+}
+
+export async function ensureSummerStore(): Promise<string> {
+  const dir = getSummerDir();
+  try {
+    await mkdir(dir, { recursive: true, mode: 0o700 });
+    const info = await lstat(dir);
+    if (info.isSymbolicLink() || !info.isDirectory()) {
+      throw new SummerStoreError(
+        "unsafe_store_directory",
+        `${dir} must be a real directory, not a file or symlink. Recovery: move it aside, create a directory at ${dir}, and run the command again.`
+      );
+    }
+    await hardenMode(dir, 0o700);
+    return dir;
+  } catch (error) {
+    if (error instanceof SummerStoreError) throw error;
+    throw new SummerStoreError(
+      "store_unavailable",
+      `Cannot secure ${dir}. Recovery: make sure the directory is owned and writable by your user, then run the command again.`
+    );
+  }
+}
+
+async function assertSafeExistingFile(path: string): Promise<boolean> {
+  try {
+    const info = await lstat(path);
+    if (info.isSymbolicLink() || !info.isFile()) {
+      throw new SummerStoreError(
+        "unsafe_store_file",
+        `${path} must be a regular file, not a directory or symlink. Recovery: move it aside and run the command again.`
+      );
+    }
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+export async function readStoreText(name: string): Promise<string | null> {
+  const path = storePath(name);
+  if (!(await assertSafeExistingFile(path))) return null;
+  try {
+    await hardenMode(path, 0o600);
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (error instanceof SummerStoreError) throw error;
+    throw new SummerStoreError(
+      "store_read_failed",
+      `Cannot read ${path}. Recovery: make sure the file is owned and readable by your user, then run the command again.`
+    );
+  }
+}
+
+export async function readStoreJson<T>(name: string): Promise<T | null> {
+  const raw = await readStoreText(name);
+  if (raw === null) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    throw new SummerStoreError(
+      "invalid_store_json",
+      `${storePath(name)} is not valid JSON. Recovery: move that file aside and run the command again.`
+    );
+  }
+}
+
+export async function writeStoreText(name: string, value: string): Promise<void> {
+  const dir = await ensureSummerStore();
+  const destination = storePath(name);
+  await assertSafeExistingFile(destination);
+  const temporary = join(dir, `.${name}.${process.pid}.${randomUUID()}.tmp`);
+
+  try {
+    await writeFile(temporary, value, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    await hardenMode(temporary, 0o600);
+    await rename(temporary, destination);
+    await hardenMode(destination, 0o600);
+  } catch (error) {
+    await rm(temporary, { force: true }).catch(() => undefined);
+    if (error instanceof SummerStoreError) throw error;
+    throw new SummerStoreError(
+      "store_write_failed",
+      `Cannot write ${destination}. Recovery: make sure ${dir} is owned and writable by your user, then run the command again.`
+    );
+  }
+}
+
+export async function writeStoreJson(name: string, value: unknown): Promise<void> {
+  await writeStoreText(name, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export async function appendStoreJsonLine(
+  name: string,
+  value: unknown
+): Promise<void> {
+  await ensureSummerStore();
+  const path = storePath(name);
+  await assertSafeExistingFile(path);
+  try {
+    await appendFile(path, `${JSON.stringify(value)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await hardenMode(path, 0o600);
+  } catch {
+    throw new SummerStoreError(
+      "store_append_failed",
+      `Cannot append to ${path}. Recovery: make sure the file is owned and writable by your user, then run the command again.`
+    );
+  }
+}
+
+export async function removeStoreFile(name: string): Promise<boolean> {
+  const path = storePath(name);
+  if (!(await assertSafeExistingFile(path))) return false;
+  try {
+    await rm(path);
+    return true;
+  } catch {
+    throw new SummerStoreError(
+      "store_remove_failed",
+      `Cannot remove ${path}. Recovery: make sure the file is owned and writable by your user, then run the command again.`
+    );
+  }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -11,6 +11,7 @@ import { registerFileTools } from "./tools/file-tools.js";
 import { registerAssetTools } from "./tools/asset-tools.js";
 import { registerGenerateTools } from "./tools/generate-tools.js";
 import { registerCloudTools } from "./tools/cloud-tools.js";
+import { registerCreatorTools } from "./tools/creator-tools.js";
 import {
   getCachedBootDriftNotice as getCachedNotice,
   setCachedBootDriftNotice,
@@ -266,6 +267,7 @@ export async function startMcpServer(): Promise<void> {
   registerAssetTools(server);
   registerGenerateTools(server);
   registerCloudTools(server);
+  registerCreatorTools(server);
 
   // Fire-and-forget — never block tool registration on the npm registry.
   void probeBootDrift().catch((error) => {

--- a/src/mcp/tools/creator-tools.test.ts
+++ b/src/mcp/tools/creator-tools.test.ts
@@ -1,0 +1,203 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { saveCreatorToken } from "../../lib/auth.js";
+import { setConfigValue } from "../../lib/config.js";
+import { setSummerDirForTests } from "../../lib/store.js";
+import { registerCreatorTools } from "./creator-tools.js";
+
+type Registered = {
+  name: string;
+  schema: Record<string, unknown>;
+  handler: (args: any) => Promise<any>;
+};
+
+function createFakeServer() {
+  const tools: Registered[] = [];
+  return {
+    tools,
+    server: {
+      tool(
+        name: string,
+        _description: string,
+        schema: Record<string, unknown>,
+        handler: (args: any) => Promise<any>
+      ) {
+        tools.push({ name, schema, handler });
+        return { name };
+      },
+    },
+  };
+}
+
+function getTool(tools: Registered[], name: string): Registered {
+  const tool = tools.find((candidate) => candidate.name === name);
+  if (!tool) throw new Error(`Tool not registered: ${name}`);
+  return tool;
+}
+
+function parseResult(result: any) {
+  return JSON.parse(result.content[0].text);
+}
+
+let root = "";
+let artifact = "";
+const GAME_ID = "11111111-1111-4111-8111-111111111111";
+const RELEASE_ID = "22222222-2222-4222-8222-222222222222";
+const TOKEN = `sc_${"c".repeat(43)}`;
+const ARTIFACT_BYTES = Buffer.from("Summer MCP PCK".padEnd(2048, "."));
+const SHA256 = createHash("sha256").update(ARTIFACT_BYTES).digest("hex");
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "summer-creator-tools-test-"));
+  artifact = join(root, "release.pck");
+  await writeFile(artifact, ARTIFACT_BYTES);
+  setSummerDirForTests(join(root, ".summer"));
+  await setConfigValue("creator.apiUrl", "http://localhost:3000");
+  await setConfigValue("creator.projectId", GAME_ID);
+  await saveCreatorToken(TOKEN);
+});
+
+afterEach(async () => {
+  setSummerDirForTests(null);
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("registerCreatorTools", () => {
+  it("extends the existing MCP with four creator tools", () => {
+    const { server, tools } = createFakeServer();
+    registerCreatorTools(server as any);
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "summer_creator_publish",
+      "summer_creator_releases",
+      "summer_creator_logs",
+      "summer_creator_config",
+    ]);
+  });
+
+  it("requires confirmation for config writes but never accepts secrets", async () => {
+    const { server, tools } = createFakeServer();
+    registerCreatorTools(server as any);
+    const config = getTool(tools, "summer_creator_config");
+
+    const refused = await config.handler({
+      action: "set",
+      key: "creator.projectId",
+      value: "project-1",
+      confirm: false,
+    });
+    expect(refused.isError).toBe(true);
+    expect(parseResult(refused).message).toContain("confirm=true");
+
+    const written = await config.handler({
+      action: "set",
+      key: "creator.projectId",
+      value: "project-1",
+      confirm: true,
+    });
+    expect(parseResult(written)).toMatchObject({
+      ok: true,
+      key: "creator.projectId",
+      value: "project-1",
+    });
+    expect(Object.keys(config.schema)).not.toContain("token");
+  });
+
+  it("runs confirmed publish through the same real creator client", async () => {
+    let call = 0;
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      call += 1;
+      if (call === 1) {
+        return Response.json({
+          contract: "summer.creator.v1",
+          operation: "prepare",
+          uploadUrl: "http://localhost:4000/upload",
+          headers: {
+            "content-type": "application/octet-stream",
+            "if-none-match": "*",
+          },
+          method: "PUT",
+          finalizeUrl: "/api/creator/v1/publish",
+        });
+      }
+      if (call === 2) {
+        expect(init?.method).toBe("PUT");
+        return new Response(null, { status: 200 });
+      }
+      return Response.json(
+        {
+          contract: "summer.creator.v1",
+          operation: "finalize",
+          releaseId: RELEASE_ID,
+          gameId: GAME_ID,
+          version: "1.0.0",
+          sha256: SHA256,
+          sizeBytes: ARTIFACT_BYTES.byteLength,
+          status: "pending_review",
+          detail: "Queued for review.",
+        },
+        { status: 201 }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { server, tools } = createFakeServer();
+    registerCreatorTools(server as any);
+    const result = await getTool(tools, "summer_creator_publish").handler({
+      project: root,
+      artifact,
+      version: "1.0.0",
+      confirm: true,
+    });
+    expect(result.isError).toBeUndefined();
+    expect(parseResult(result)).toMatchObject({
+      ok: true,
+      operation: "publish",
+      releaseId: RELEASE_ID,
+      status: "pending_review",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns real release history and preserves the opaque cursor", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        contract: "summer.creator.v1",
+        gameId: GAME_ID,
+        releases: [
+          {
+            releaseId: RELEASE_ID,
+            gameId: GAME_ID,
+            version: "1.0.0",
+            state: "pending_review",
+            gameStatus: "review",
+            sha256: "a".repeat(64),
+            sizeBytes: 2048,
+            changelog: null,
+            submittedAt: "2026-07-30T12:00:00.000Z",
+            artifactPlane: "r2",
+          },
+        ],
+        nextCursor: "cursor-2",
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { server, tools } = createFakeServer();
+    registerCreatorTools(server as any);
+
+    const result = await getTool(tools, "summer_creator_releases").handler({
+      limit: 20,
+      cursor: "cursor-1",
+    });
+    expect(parseResult(result)).toMatchObject({
+      ok: true,
+      operation: "releases",
+      nextCursor: "cursor-2",
+      releases: [{ releaseId: RELEASE_ID }],
+    });
+  });
+});

--- a/src/mcp/tools/creator-tools.ts
+++ b/src/mcp/tools/creator-tools.ts
@@ -1,0 +1,167 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  CreatorOperationError,
+  listCreatorReleases,
+  publishCreator,
+  readCreatorLogs,
+} from "../../lib/creator.js";
+import {
+  CONFIG_KEYS,
+  getConfigValue,
+  isConfigKey,
+  readSummerConfig,
+  setConfigValue,
+  unsetConfigValue,
+} from "../../lib/config.js";
+
+function textJson(value: unknown, isError = false) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(value, null, 2),
+      },
+    ],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+async function creatorResult<T>(operation: () => Promise<T>) {
+  try {
+    return textJson(await operation());
+  } catch (error) {
+    if (error instanceof CreatorOperationError) {
+      return textJson(
+        {
+          ok: false,
+          code: error.code,
+          operation: error.operation,
+          message: error.message,
+          recovery: error.recovery,
+        },
+        true
+      );
+    }
+    return textJson(
+      {
+        ok: false,
+        code: "creator_request_invalid",
+        message: error instanceof Error ? error.message : String(error),
+      },
+      true
+    );
+  }
+}
+
+export function registerCreatorTools(server: McpServer): void {
+  server.tool(
+    "summer_creator_publish",
+    "Publish an exact exported Summer .pck through the versioned Summercraft creator API. First call with confirm=false and present the returned project, version, digest, size, artifact path, channel, and notes; set confirm only after the user approves that exact target. The server independently verifies token scope, ownership, bytes, and review state.",
+    {
+      project: z.string().optional().describe("Project root. Defaults to the current working directory."),
+      artifact: z.string().describe("Exact path to the exported Summer .pck artifact."),
+      version: z.string().describe("Immutable release version."),
+      manifest: z.string().optional().describe("Optional path to a JSON release manifest."),
+      projectId: z.string().optional().describe("Creator project ID. Defaults to ~/.summer/config.json."),
+      channel: z.string().optional().describe("Release channel. Defaults to the configured channel or production."),
+      notes: z.string().optional().describe("Release notes shown during confirmation and recorded in the local audit."),
+      confirm: z.boolean().default(false).describe("Set true only after the user approves the exact release target."),
+    },
+    async (args) =>
+      creatorResult(() =>
+        publishCreator({
+          ...args,
+          face: "mcp",
+        })
+      )
+  );
+
+  server.tool(
+    "summer_creator_releases",
+    "List real creator-owned releases from the versioned Summercraft creator API. The server independently verifies the exact publish scope and project ownership.",
+    {
+      projectId: z.string().optional().describe("Creator project ID. Defaults to ~/.summer/config.json."),
+      limit: z.number().int().min(1).max(100).default(20),
+      cursor: z.string().optional().describe("Opaque nextCursor from the previous page."),
+    },
+    async (args) =>
+      creatorResult(() =>
+        listCreatorReleases({
+          ...args,
+          face: "mcp",
+        })
+      )
+  );
+
+  server.tool(
+    "summer_creator_logs",
+    "Read creator runtime logs for a project or release. If the required platform route or token scope is unavailable, returns the exact recovery action instead of placeholder logs.",
+    {
+      projectId: z.string().optional().describe("Creator project ID. Defaults to ~/.summer/config.json."),
+      releaseId: z.string().optional().describe("Optional release ID."),
+      limit: z.number().int().min(1).max(1000).default(100),
+    },
+    async (args) =>
+      creatorResult(() =>
+        readCreatorLogs({
+          ...args,
+          face: "mcp",
+        })
+      )
+  );
+
+  server.tool(
+    "summer_creator_config",
+    "Read or update the shared non-secret ~/.summer configuration used by the CLI and this MCP. Mutations require confirm=true. Tokens are never returned or accepted by this tool.",
+    {
+      action: z.enum(["list", "get", "set", "unset"]),
+      key: z.enum(CONFIG_KEYS).optional(),
+      value: z.string().optional(),
+      confirm: z.boolean().default(false),
+    },
+    async ({ action, key, value, confirm }) =>
+      creatorResult(async () => {
+        if (action === "list") {
+          const config = await readSummerConfig();
+          return {
+            ok: true,
+            values: Object.fromEntries(
+              CONFIG_KEYS.map((name) => [
+                name,
+                getConfigValue(config, name) ?? null,
+              ])
+            ),
+          };
+        }
+        if (!key || !isConfigKey(key)) {
+          throw new Error(
+            `A valid key is required. Recovery: use one of ${CONFIG_KEYS.join(", ")}.`
+          );
+        }
+        if (action === "get") {
+          return {
+            ok: true,
+            key,
+            value: getConfigValue(await readSummerConfig(), key) ?? null,
+          };
+        }
+        if (!confirm) {
+          throw new Error(
+            `Changing ${key} requires confirmation. Recovery: show the exact change to the user, then retry with confirm=true.`
+          );
+        }
+        if (action === "set") {
+          if (value === undefined) {
+            throw new Error(
+              `A value is required for ${key}. Recovery: provide value and retry with confirm=true.`
+            );
+          }
+          const config = await setConfigValue(key, value);
+          return { ok: true, key, value: getConfigValue(config, key) };
+        }
+        const config = await unsetConfigValue(key);
+        return { ok: true, key, value: getConfigValue(config, key) ?? null };
+      })
+  );
+}

--- a/tests/specs/art-direction.md
+++ b/tests/specs/art-direction.md
@@ -2,7 +2,7 @@
 
 ## Fixture
 
-- Godot 4.5 / Summer Engine project, main scene with `World/WorldEnvironment` and `World/Sun` (DirectionalLight3D) present.
+- Summer Engine project, main scene with `World/WorldEnvironment` and `World/Sun` (DirectionalLight3D) present.
 - `.summer/GameSoul.md` exists; brief: "Cozy farming sim, vertical slice scope."
 - No `.summer/art-bible.md` yet.
 - Summer MCP available.

--- a/tests/specs/audio-direction.md
+++ b/tests/specs/audio-direction.md
@@ -2,7 +2,7 @@
 
 ## Fixture
 
-- Godot 4.5 / Summer Engine project, default audio bus layout (Master only).
+- Summer Engine project, default audio bus layout (Master only).
 - `.summer/GameSoul.md` exists; brief: "Cozy farming sim, vertical slice scope."
 - `.summer/art-bible.md` exists; mood: "soft, hand-warmed, golden-hour, painterly".
 - No `.summer/audio-bible.md` yet.

--- a/tests/specs/brainstorm-game.md
+++ b/tests/specs/brainstorm-game.md
@@ -2,7 +2,7 @@
 
 ## Fixture
 
-- Empty Godot 4.5 / Summer Engine project, `project.godot` exists, no `.summer/` folder yet.
+- Empty Summer Engine project, `project.godot` exists, no `.summer/` folder yet.
 - Summer MCP available.
 - Host file tools available (Read, Write, Edit).
 

--- a/tests/specs/design-level.md
+++ b/tests/specs/design-level.md
@@ -2,7 +2,7 @@
 
 ## Fixture
 
-- Godot 4.5 / Summer Engine project, main scene already has a `World/Player` (CharacterBody3D) with FPS controller wired.
+- Summer Engine project, main scene already has a `World/Player` (CharacterBody3D) with FPS controller wired.
 - `.summer/GameSoul.md` exists; brief: "Action-combat game, three mechanics: dash, parry, double-jump. Vertical slice scope."
 - `.summer/mechanics/parry.md` exists.
 - No `levels/` folder yet.

--- a/tests/specs/design-mechanic.md
+++ b/tests/specs/design-mechanic.md
@@ -2,7 +2,7 @@
 
 ## Fixture
 
-- Godot 4.5 / Summer Engine project with `World/Player` (CharacterBody3D + CollisionShape3D + Camera3D) already in the main scene.
+- Summer Engine project with `World/Player` (CharacterBody3D + CollisionShape3D + Camera3D) already in the main scene.
 - A `scripts/player_controller.gd` exists with single-jump logic.
 - `.summer/GameSoul.md` exists, brief says: "core loop is precise platforming, three mechanics: dash, double-jump, parry".
 - Summer MCP available.

--- a/tests/specs/design-npc.md
+++ b/tests/specs/design-npc.md
@@ -2,7 +2,7 @@
 
 ## Fixture
 
-- Godot 4.5 / Summer Engine project, main scene with `World/Player` (CharacterBody3D in `player` group) and an empty `World/Enemies` parent.
+- Summer Engine project, main scene with `World/Player` (CharacterBody3D in `player` group) and an empty `World/Enemies` parent.
 - Summer MCP tools available.
 - Host file tools available (Read, Edit, Write).
 

--- a/tests/specs/export-and-ship.md
+++ b/tests/specs/export-and-ship.md
@@ -2,7 +2,7 @@
 
 ## Fixture
 
-- Godot 4.5 / Summer Engine project, complete game with main scene set, no script errors, basic icon at `icon.png` (256×256).
+- Summer Engine project, complete game with main scene set, no script errors, basic icon at `icon.png` (256×256).
 - Existing `export_presets.cfg` with Windows/Mac/Linux presets, all `debug = true` (development defaults).
 - No `LICENSE` file at repo root.
 - No `attribution.md`.

--- a/tests/specs/fps-controller.md
+++ b/tests/specs/fps-controller.md
@@ -2,7 +2,7 @@
 
 ## Fixture
 
-- Empty Godot 4.5 / Summer Engine project, main scene open with a single `World` (Node3D) root.
+- Empty Summer Engine project, main scene open with a single `World` (Node3D) root.
 - Summer MCP tools available (engine running on localhost:6550).
 - No existing input actions in InputMap beyond Godot defaults.
 - No script files attached.

--- a/tests/specs/host-authoritative-state.md
+++ b/tests/specs/host-authoritative-state.md
@@ -2,7 +2,7 @@
 
 ## Fixture
 
-- A Godot 4.5 / Summer Engine project with `/peer-to-peer-multiplayer` Layer 1 already done — `NetworkManager` autoload exists, exposes `peer_joined` / `peer_left` signals.
+- A Summer Engine project with `/peer-to-peer-multiplayer` Layer 1 already done — `NetworkManager` autoload exists, exposes `peer_joined` / `peer_left` signals.
 - Project may have a partial player scene; no Managers yet.
 - Summer MCP tools available; engine on localhost:6550.
 

--- a/tests/specs/peer-to-peer-multiplayer.md
+++ b/tests/specs/peer-to-peer-multiplayer.md
@@ -2,7 +2,7 @@
 
 ## Fixture
 
-- A Godot 4.5 / Summer Engine project that does NOT yet have multiplayer.
+- A Summer Engine project that does NOT yet have multiplayer.
 - Project may be empty or may have an existing single-player scene.
 - Summer MCP tools available; engine running on localhost:6550.
 
@@ -78,7 +78,7 @@
 
 **Fixture:** Same as Case 1, but Summer MCP unavailable.
 
-**Input:** "Add multiplayer to my Godot game (P2P, friend invite)."
+**Input:** "Add multiplayer to my Summer game (P2P, friend invite)."
 
 **Expected behavior:**
 

--- a/tests/specs/setup-multiplayer.md
+++ b/tests/specs/setup-multiplayer.md
@@ -2,7 +2,7 @@
 
 ## Fixture
 
-- Godot 4.5 / Summer Engine project, single-player game with `World/Player` (CharacterBody3D) and a working camera + movement script.
+- Summer Engine project, single-player game with `World/Player` (CharacterBody3D) and a working camera + movement script.
 - Summer MCP tools available.
 - Host file tools available (Read, Edit, Write).
 - No multiplayer setup yet (no autoloads, no MultiplayerSpawner, no Synchronizer).
@@ -96,7 +96,7 @@
 **Assertions:**
 
 - [ ] Skill does not blindly call `summer_*` tools and fail.
-- [ ] Generated scripts compile in Godot 4.5 / Summer Engine.
+- [ ] Generated scripts compile in Summer Engine.
 - [ ] Skill provides a `project.godot` patch in valid Godot project format.
 - [ ] Skill still asks for confirmation on each write.
 - [ ] Same opinionated decisions hold (host authority, ENet, no replication of cosmetic VFX).

--- a/tests/specs/tune-performance.md
+++ b/tests/specs/tune-performance.md
@@ -2,7 +2,7 @@
 
 ## Fixture
 
-- Godot 4.5 / Summer Engine project with a 3D scene.
+- Summer Engine project with a 3D scene.
 - Summer MCP tools available (engine running on localhost:6550).
 - Host file tools available (Read, Edit, Write).
 

--- a/tests/specs/vfx.md
+++ b/tests/specs/vfx.md
@@ -2,7 +2,7 @@
 
 ## Fixture
 
-- Godot 4.5 / Summer Engine project, main scene with `World/Player` (CharacterBody3D + Camera3D) and `World/Enemy` (CharacterBody3D + MeshInstance3D + a `damaged(amount)` signal).
+- Summer Engine project, main scene with `World/Player` (CharacterBody3D + Camera3D) and `World/Enemy` (CharacterBody3D + MeshInstance3D + a `damaged(amount)` signal).
 - `default_bus_layout.tres` defines `Master`, `Music`, `Ambient`, `SFX` buses (at minimum).
 - Summer MCP tools available (engine running on localhost:6550).
 - Host file tools available (Read, Edit, Write).
@@ -105,7 +105,7 @@
 **Assertions:**
 
 - [ ] Skill identifies MCP unavailable and adapts.
-- [ ] Generated GDScript is syntactically valid Godot 4.5 with type hints.
+- [ ] Generated GDScript is syntactically valid Summer Engine with type hints.
 - [ ] Skill asks the user to paste the scene snippet AND the bus list.
 - [ ] Skill provides explicit autoload-registration instructions (no `summer_*` autoload tool exists).
 - [ ] Skill applies "May I write …" protocol on each of the 3 file writes.


### PR DESCRIPTION
## Summary

- ship the canonical npm client's shared CLI/MCP implementation for `summer.creator.v1`
- add exact-target confirmation, prepare → streamed write-once PUT → finalize, real creator-owned release history, and explicit fail-closed runtime logs
- keep Summercraft `creator-token` separate from the Engine-owned core `auth-token`; add a hardened shared store and typed non-secret config
- register `summer publish`, `summer releases`, `summer logs`, `summer config`, `summer login --creator`, and four matching MCP tools
- clean the canonical public identity: Summer game / Summer SDK / GDScript first, remove fixed-4.5 and false mirror copy, document current upstream base 4.6.1 with planned 4.7.1/continuous following only in the technical compatibility note
- state current public installer availability honestly: macOS Apple silicon and Windows; Steam/browser/mobile/Linux remain planned targets

## Verification

- `npm run build`
- `npm test` — 39 files, 375 tests passed (including local-loopback integration tests)
- focused creator/auth/MCP/public-language checks — 34 passed
- `npm pack --dry-run --json` — creator runtime files and `references/` included
- `git diff --check`

## Boundaries / residuals

- no npm publish, deployment, production request, migration, environment change, secret write, or key rotation was performed
- runtime logs remain unsupported until the platform owns durable ingestion, retention, redaction, authorization, and query semantics
- after merge and a separately approved npm release, run one disposable-token publish/release-history witness and revoke the token
- a broader context-by-context audit of remaining technically necessary upstream references is still follow-up work; this PR removes the literal stale/product-led cases without erasing legal/history or node/file-format facts