### PR TITLE
Route MCP sessions to matching editor instances

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ technical compatibility reference for version-sensitive upstream APIs.
 - **Discipline** (`gdscript-patterns`, `scene-composition`, `art-direction`) → how to shape it.
 - **Build** (`fps-controller`, `design-mechanic`, `design-level`, `setup-multiplayer`, `vfx`, `tune-performance`, `export-and-ship`) → produce the artifact.
 
-## MCP tool palette (engine on `localhost:6550`)
+## MCP tool palette (project-matched local editor)
 
 62 tools total. Categories:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to summer-engine will be documented here. Following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- MCP discovers every live Summer editor through `~/.summer/instances/` and automatically binds local tools to the editor whose project contains the agent's current working directory.
+- `summer mcp --project <path>` and `summer mcp --instance <id>` provide explicit selection for hosts that do not start the MCP server from a project directory.
+
+### Changed
+- Multiple live editors are now a fail-closed state when no project can be inferred. MCP lists the non-secret project/instance choices instead of following the machine-global last-opened editor pointer.
+- Selected MCP sessions keep following the same project across editor restarts and validate registry identity against `/api/health` before connecting.
+
 ## [2.7.0] — 2026-07-24 — "Reliable project mutations"
 
 ### Added

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -23,7 +23,7 @@ The single most important skill to know is `summer:using-summer` — it explains
 2. **Discipline skills second**: `gdscript-patterns`, `scene-composition`, `art-direction`, `audio-direction`. These shape content.
 3. **Build skills third**: `fps-controller`, `design-mechanic`, `design-level`, `setup-multiplayer`, `vfx`, `tune-performance`, `export-and-ship`.
 
-## MCP tools (when the engine is running on `localhost:6550`)
+## MCP tools (when the project-matched local editor is running)
 
 The `summer-engine` MCP server exposes 62 tools. The most important:
 

--- a/README.md
+++ b/README.md
@@ -262,9 +262,9 @@ Two pieces, plus the glue.
 Skills don't list steps. They encode the **order of operations**: diagnose before editing, scope before building, ask before guessing. [Agent Skills](https://agentskills.io) format, so any conformant tool picks them up.
 
 **MCP bridge.** The `summer-engine` MCP server gives the agent 62 tools. Local
-project tools connect to your engine on `localhost:6550`; cloud and creator
-tools use their documented remote or local contracts without requiring the
-editor:
+project tools connect to the project-matched live editor on its loopback port;
+cloud and creator tools use their documented remote or local contracts without
+requiring the editor:
 
 | | |
 |---|---|
@@ -279,6 +279,13 @@ editor:
 | Creator | `summer_creator_publish`, `summer_creator_releases`, `summer_creator_logs`, `summer_creator_config` — confirmed immutable publishing, real release history, explicit unsupported logs, and non-secret shared configuration |
 
 Git, shell, and grep remain host-native. Project file reads and writes use Summer's identity-bound tools so compatible engine builds can reject wrong-project and stale-content mutations. A host agent can still bypass these safeguards with its own file tools; the package cannot technically intercept that external process.
+
+When several Summer editors are open, MCP automatically selects the one whose
+project contains the agent's current working directory. Normal agent configs do
+not need a path or one MCP entry per editor. Hosts that launch MCP outside a
+project can use `summer mcp --project <path>`; `--instance <id>` is available
+when two editors intentionally show the same project. An ambiguous unscoped
+connection is rejected rather than routed to the last editor that opened.
 
 **Lifecycle hooks.** A `session-start` hook detects whether you're in a Summer Engine project and feeds the agent a one-line orientation. An opt-in `pre-commit doctor` runs `summer doctor` before `git commit` and blocks when the setup needs attention.
 
@@ -508,7 +515,7 @@ npx -y summer-engine@latest doctor
 | `summer skills list` | Show all skills. |
 | `summer skills install <name>` | Install one. |
 | `summer skills install --recommended --agent <agent>` | Install the recommended set. |
-| `summer mcp` | Start the MCP server. |
+| `summer mcp [--project <path> \| --instance <id>]` | Start MCP; normally auto-binds from the agent's project directory. |
 | `summer mcp setup <agent>` | Write MCP config for an agent. |
 | `summer setup <agent> [--yes]` | One shot: MCP config + recommended skills + doctor. |
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -185,6 +185,20 @@ tools/summer-cli/
 
 The MCP server does NOT require the engine to be running at startup. It starts immediately, registers all tools, and connects to the engine lazily on first tool call. If the engine stops mid-session, the next tool call retries. This is handled by `with-engine.ts`.
 
+### Multi-Editor Discovery
+
+Current desktop builds publish one secured registry entry per live editor at
+`~/.summer/instances/<instanceId>.json`. On MCP startup, the CLI walks upward
+from its current working directory to find `project.godot`, matches that
+project root to the registry, and validates the chosen instance against
+`/api/health` before using its port and token.
+
+Selection priority is an explicit `--instance`, an explicit `--project`, the
+agent's current project directory, then the only live instance. If multiple
+instances remain and no project is known, connection fails closed. The legacy
+`api-port`/`api-token` pair remains as a compatibility fallback when no live
+registry entries exist.
+
 ### Shared `~/.summer/` Store
 
 The CLI, existing MCP, exporters, and desktop engine share one secured

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -9,8 +9,19 @@ import { startMcpServer } from "../mcp/server.js";
 
 export const mcpCommand = new Command("mcp")
   .description("Start the MCP server for AI tool integration (Cursor, Claude Code, etc.)")
-  .action(async () => {
-    await startMcpServer();
+  .option(
+    "--project <path>",
+    "Bind local engine tools to the editor running this project"
+  )
+  .option(
+    "--instance <id>",
+    "Bind local engine tools to one exact Summer editor instance"
+  )
+  .action(async (opts: { project?: string; instance?: string }) => {
+    await startMcpServer({
+      projectPath: opts.project,
+      instanceId: opts.instance,
+    });
   });
 
 mcpCommand

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -2,7 +2,13 @@ import { mkdir, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { randomUUID } from "node:crypto";
-import { getApiToken, getApiPort, checkEngineHealth } from "./engine.js";
+import {
+  getApiToken,
+  getApiPort,
+  checkEngineHealth,
+  resolveEngineConnection,
+  type EngineSelection,
+} from "./engine.js";
 import {
   classifyOpsResponse,
   pollOpToTerminal,
@@ -155,11 +161,13 @@ export class EngineApiClient {
   // preserves the pre-2.6.6 constructor contract for existing callers that only
   // supplied a projectIdHash.
   private targetIdentity: EngineTargetIdentity;
+  private selection: EngineSelection | null;
 
   constructor(
     port: number,
     token: string,
-    targetIdentity: EngineTargetIdentity | string = {}
+    targetIdentity: EngineTargetIdentity | string = {},
+    selection: EngineSelection | null = null
   ) {
     this.port = port;
     this.token = token;
@@ -167,9 +175,26 @@ export class EngineApiClient {
       typeof targetIdentity === "string"
         ? { projectIdHash: targetIdentity }
         : { ...targetIdentity };
+    this.selection = selection ? { ...selection } : null;
   }
 
-  static async connect(): Promise<EngineApiClient> {
+  static async connect(
+    selection?: EngineSelection
+  ): Promise<EngineApiClient> {
+    if (selection) {
+      const connection = await resolveEngineConnection(selection);
+      return new EngineApiClient(
+        connection.port,
+        connection.token,
+        {
+          instanceId: connection.health.instanceId,
+          projectId: connection.health.projectId,
+          projectIdHash: connection.health.projectIdHash,
+        },
+        { ...selection }
+      );
+    }
+
     const port = await getApiPort();
     const token = await getApiToken();
 
@@ -741,6 +766,22 @@ export class EngineApiClient {
    * will fail and trigger a reconnect+retry if the client really is stale.
    */
   async credentialsChanged(): Promise<boolean> {
+    if (this.selection) {
+      try {
+        const connection = await resolveEngineConnection(this.selection);
+        return (
+          connection.port !== this.port ||
+          connection.token !== this.token ||
+          connection.health.instanceId !== this.targetIdentity.instanceId
+        );
+      } catch {
+        // A selected editor disappearing is real drift. Dropping the cached
+        // client makes the next connect report which project/instance is absent
+        // instead of silently following another editor's global pointer.
+        return true;
+      }
+    }
+
     try {
       const [port, token] = await Promise.all([getApiPort(), getApiToken()]);
       if (!token) return false;

--- a/src/lib/engine.test.ts
+++ b/src/lib/engine.test.ts
@@ -1,0 +1,208 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  listEngineInstances,
+  resolveEngineConnection,
+  type EngineInstance,
+} from "./engine.js";
+
+let testRoot: string | null = null;
+
+async function setupRoot(): Promise<string> {
+  testRoot = await mkdtemp(join(tmpdir(), "summer-engine-discovery-"));
+  const summerDir = join(testRoot, ".summer");
+  await mkdir(join(summerDir, "instances"), { recursive: true });
+  return testRoot;
+}
+
+function discoveryOptions(): { summerDir: string } {
+  if (!testRoot) throw new Error("test root not initialized");
+  return { summerDir: join(testRoot, ".summer") };
+}
+
+async function createProject(name: string): Promise<string> {
+  if (!testRoot) throw new Error("test root not initialized");
+  const root = join(testRoot, name);
+  await mkdir(join(root, "scripts"), { recursive: true });
+  await writeFile(join(root, "project.godot"), `[application]\nconfig/name="${name}"\n`);
+  return root;
+}
+
+async function registerInstance(
+  projectRoot: string,
+  overrides: Partial<EngineInstance> = {}
+): Promise<EngineInstance> {
+  const projectName = basename(projectRoot);
+  const instance: EngineInstance = {
+    schemaVersion: 1,
+    instanceId: overrides.instanceId ?? `instance-${projectName}`,
+    pid: overrides.pid ?? process.pid,
+    port: overrides.port ?? 6550,
+    token: overrides.token ?? `token-${projectName}`,
+    projectId: overrides.projectId ?? `project-${projectName}`,
+    projectIdHash: overrides.projectIdHash ?? `hash-${projectName}`,
+    resourceRoot: projectRoot,
+    projectName: overrides.projectName ?? projectName,
+    heartbeatAt: overrides.heartbeatAt ?? Math.floor(Date.now() / 1000),
+    engineVersion: "0.5.58",
+  };
+  const instancesDir = join(testRoot!, ".summer", "instances");
+  await writeFile(
+    join(instancesDir, `${instance.instanceId}.json`),
+    JSON.stringify(instance)
+  );
+  return instance;
+}
+
+function mockHealth(instances: EngineInstance[]): void {
+  vi.stubGlobal("fetch", async (input: unknown) => {
+    const port = Number(new URL(String(input)).port);
+    const instance = instances.find((candidate) => candidate.port === port);
+    if (!instance) return new Response("", { status: 404 });
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        engine: "summer",
+        version: instance.engineVersion,
+        port: instance.port,
+        pid: instance.pid,
+        instanceId: instance.instanceId,
+        projectId: instance.projectId,
+        projectIdHash: instance.projectIdHash,
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  });
+}
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  if (testRoot) {
+    await rm(testRoot, { recursive: true, force: true });
+    testRoot = null;
+  }
+});
+
+describe("per-instance Summer editor discovery", () => {
+  it("automatically binds an agent to the editor for its current project", async () => {
+    await setupRoot();
+    const projectA = await createProject("game-a");
+    const projectB = await createProject("game-b");
+    const a = await registerInstance(projectA, { port: 6550 });
+    const b = await registerInstance(projectB, { port: 6551 });
+    mockHealth([a, b]);
+
+    const connection = await resolveEngineConnection(
+      { cwd: join(projectB, "scripts") },
+      discoveryOptions()
+    );
+
+    expect(connection.source).toBe("registry");
+    expect(connection.instance?.instanceId).toBe(b.instanceId);
+    expect(connection.port).toBe(6551);
+    expect(connection.token).toBe(b.token);
+  });
+
+  it("supports an explicit instance when two editors show the same project", async () => {
+    await setupRoot();
+    const project = await createProject("shared-game");
+    const a = await registerInstance(project, {
+      instanceId: "editor-a",
+      port: 6550,
+    });
+    const b = await registerInstance(project, {
+      instanceId: "editor-b",
+      port: 6551,
+    });
+    mockHealth([a, b]);
+
+    const connection = await resolveEngineConnection(
+      {
+        projectPath: project,
+        instanceId: "editor-b",
+      },
+      discoveryOptions()
+    );
+
+    expect(connection.instance?.instanceId).toBe("editor-b");
+  });
+
+  it("lets an explicit instance override an unrelated MCP working directory", async () => {
+    await setupRoot();
+    const projectA = await createProject("game-a");
+    const projectB = await createProject("game-b");
+    const a = await registerInstance(projectA, { port: 6550 });
+    const b = await registerInstance(projectB, {
+      instanceId: "editor-b",
+      port: 6551,
+    });
+    mockHealth([a, b]);
+
+    const connection = await resolveEngineConnection(
+      {
+        instanceId: "editor-b",
+        cwd: join(projectA, "scripts"),
+      },
+      discoveryOptions()
+    );
+
+    expect(connection.instance?.instanceId).toBe("editor-b");
+  });
+
+  it("fails closed when multiple editors are live and no project can be inferred", async () => {
+    const root = await setupRoot();
+    const projectA = await createProject("game-a");
+    const projectB = await createProject("game-b");
+    const a = await registerInstance(projectA, { port: 6550 });
+    const b = await registerInstance(projectB, { port: 6551 });
+    mockHealth([a, b]);
+
+    await expect(
+      resolveEngineConnection({ cwd: root }, discoveryOptions())
+    ).rejects.toThrow(/Multiple Summer editors are running/);
+  });
+
+  it("ignores stale or dead registry entries", async () => {
+    await setupRoot();
+    const project = await createProject("stale-game");
+    await registerInstance(project, {
+      pid: 2_147_483_647,
+      heartbeatAt: Math.floor(Date.now() / 1000) - 600,
+    });
+
+    await expect(
+      listEngineInstances(Date.now(), discoveryOptions().summerDir)
+    ).resolves.toEqual([]);
+  });
+
+  it("keeps the legacy global pointer fallback for older engine builds", async () => {
+    await setupRoot();
+    const project = await createProject("legacy-game");
+    await writeFile(join(testRoot!, ".summer", "api-port"), "6550\n");
+    await writeFile(join(testRoot!, ".summer", "api-token"), "legacy-token\n");
+    const legacy: EngineInstance = {
+      schemaVersion: 1,
+      instanceId: "legacy-editor",
+      pid: process.pid,
+      port: 6550,
+      token: "legacy-token",
+      resourceRoot: "/not-published",
+      heartbeatAt: Math.floor(Date.now() / 1000),
+      engineVersion: "0.5.55",
+    };
+    mockHealth([legacy]);
+
+    const connection = await resolveEngineConnection(
+      { cwd: join(project, "scripts") },
+      discoveryOptions()
+    );
+
+    expect(connection.source).toBe("legacy");
+    expect(connection.port).toBe(6550);
+    expect(connection.token).toBe("legacy-token");
+  });
+});

--- a/src/lib/engine.ts
+++ b/src/lib/engine.ts
@@ -1,26 +1,355 @@
-import { readFile } from "fs/promises";
-import { join } from "path";
+import { lstat, readFile, readdir, realpath, stat } from "fs/promises";
+import { dirname, join, resolve } from "path";
 import { getSummerDir } from "./auth.js";
 
 const DEFAULT_PORT = 6550;
+const INSTANCE_SCHEMA_VERSION = 1;
+const INSTANCE_STALE_MS = 180_000;
+const MAX_INSTANCE_FILE_BYTES = 64 * 1024;
 
-export async function getApiToken(): Promise<string | null> {
+export interface EngineSelection {
+  instanceId?: string;
+  projectPath?: string;
+  cwd?: string;
+}
+
+export interface EngineDiscoveryOptions {
+  summerDir?: string;
+  nowMs?: number;
+}
+
+export interface EngineInstance {
+  schemaVersion: 1;
+  instanceId: string;
+  pid: number;
+  port: number;
+  token: string;
+  projectId?: string;
+  projectIdHash?: string;
+  resourceRoot: string;
+  projectName?: string;
+  heartbeatAt: number;
+  engineVersion?: string;
+}
+
+export interface EngineConnection {
+  port: number;
+  token: string;
+  health: EngineHealth;
+  instance?: EngineInstance;
+  selection: EngineSelection | null;
+  source: "registry" | "legacy";
+}
+
+export async function getApiToken(
+  summerDir = getSummerDir()
+): Promise<string | null> {
   try {
-    const token = await readFile(join(getSummerDir(), "api-token"), "utf-8");
+    const token = await readFile(join(summerDir, "api-token"), "utf-8");
     return token.trim() || null;
   } catch {
     return null;
   }
 }
 
-export async function getApiPort(): Promise<number> {
+export async function getApiPort(
+  summerDir = getSummerDir()
+): Promise<number> {
   try {
-    const port = await readFile(join(getSummerDir(), "api-port"), "utf-8");
+    const port = await readFile(join(summerDir, "api-port"), "utf-8");
     const parsed = parseInt(port.trim(), 10);
     return isNaN(parsed) ? DEFAULT_PORT : parsed;
   } catch {
     return DEFAULT_PORT;
   }
+}
+
+function stringFromUnknown(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function numberFromUnknown(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function processIsAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function canonicalPath(path: string): Promise<string> {
+  const absolute = resolve(path);
+  try {
+    return await realpath(absolute);
+  } catch {
+    return absolute;
+  }
+}
+
+export async function findProjectRoot(
+  startPath: string
+): Promise<string | null> {
+  let current = await canonicalPath(startPath);
+  try {
+    if (!(await stat(current)).isDirectory()) {
+      current = dirname(current);
+    }
+  } catch {
+    return null;
+  }
+
+  while (true) {
+    try {
+      if ((await stat(join(current, "project.godot"))).isFile()) {
+        return current;
+      }
+    } catch {
+      // Keep walking toward the filesystem root.
+    }
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function parseEngineInstance(value: unknown): EngineInstance | null {
+  const record = asRecord(value);
+  if (!record || record.schemaVersion !== INSTANCE_SCHEMA_VERSION) return null;
+
+  const instanceId = stringFromUnknown(record.instanceId);
+  const pid = numberFromUnknown(record.pid);
+  const port = numberFromUnknown(record.port);
+  const token = stringFromUnknown(record.token);
+  const resourceRoot = stringFromUnknown(record.resourceRoot);
+  const heartbeatAt = numberFromUnknown(record.heartbeatAt);
+
+  if (
+    !instanceId ||
+    !pid ||
+    !Number.isInteger(pid) ||
+    !port ||
+    !Number.isInteger(port) ||
+    port < 1 ||
+    port > 65535 ||
+    !token ||
+    !resourceRoot ||
+    !heartbeatAt
+  ) {
+    return null;
+  }
+
+  return {
+    schemaVersion: 1,
+    instanceId,
+    pid,
+    port,
+    token,
+    projectId: stringFromUnknown(record.projectId),
+    projectIdHash: stringFromUnknown(record.projectIdHash),
+    resourceRoot,
+    projectName: stringFromUnknown(record.projectName),
+    heartbeatAt,
+    engineVersion: stringFromUnknown(record.engineVersion),
+  };
+}
+
+export async function listEngineInstances(
+  nowMs = Date.now(),
+  summerDir = getSummerDir()
+): Promise<EngineInstance[]> {
+  const instancesDir = join(summerDir, "instances");
+  try {
+    const dirInfo = await lstat(instancesDir);
+    if (!dirInfo.isDirectory() || dirInfo.isSymbolicLink()) return [];
+  } catch {
+    return [];
+  }
+
+  const entries = await readdir(instancesDir, { withFileTypes: true });
+  const instances: EngineInstance[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const path = join(instancesDir, entry.name);
+    try {
+      const info = await lstat(path);
+      if (
+        !info.isFile() ||
+        info.isSymbolicLink() ||
+        info.size > MAX_INSTANCE_FILE_BYTES
+      ) {
+        continue;
+      }
+      const parsed = parseEngineInstance(
+        JSON.parse(await readFile(path, "utf-8"))
+      );
+      if (!parsed || !processIsAlive(parsed.pid)) continue;
+      if (nowMs - parsed.heartbeatAt * 1000 > INSTANCE_STALE_MS) continue;
+      parsed.resourceRoot = await canonicalPath(parsed.resourceRoot);
+      instances.push(parsed);
+    } catch {
+      // One malformed or concurrently-replaced entry must not hide other editors.
+    }
+  }
+
+  return instances.sort((a, b) =>
+    a.resourceRoot.localeCompare(b.resourceRoot) ||
+    a.instanceId.localeCompare(b.instanceId)
+  );
+}
+
+function formatInstances(instances: EngineInstance[]): string {
+  return instances
+    .map((instance) => {
+      const label = instance.projectName
+        ? `${instance.projectName} (${instance.resourceRoot})`
+        : instance.resourceRoot;
+      return `  - ${label} [${instance.instanceId}]`;
+    })
+    .join("\n");
+}
+
+async function connectionForInstance(
+  instance: EngineInstance,
+  selection: EngineSelection
+): Promise<EngineConnection> {
+  const health = await checkEngineHealth(instance.port);
+  if (!health) {
+    throw new Error(
+      `Summer Engine instance ${instance.instanceId} is not responding on port ${instance.port}.`
+    );
+  }
+  if (health.instanceId !== instance.instanceId) {
+    throw new Error(
+      `Summer Engine registry identity changed on port ${instance.port}; refusing to connect to the wrong editor.`
+    );
+  }
+  if (
+    instance.projectIdHash &&
+    health.projectIdHash &&
+    instance.projectIdHash !== health.projectIdHash
+  ) {
+    throw new Error(
+      `Summer Engine project identity changed on port ${instance.port}; refusing to connect to the wrong project.`
+    );
+  }
+
+  return {
+    port: instance.port,
+    token: instance.token,
+    health,
+    instance,
+    selection: { ...selection },
+    source: "registry",
+  };
+}
+
+export async function resolveEngineConnection(
+  selection: EngineSelection = {},
+  options: EngineDiscoveryOptions = {}
+): Promise<EngineConnection> {
+  const summerDir = options.summerDir ?? getSummerDir();
+  const explicitInstanceId = stringFromUnknown(selection.instanceId);
+  const explicitProjectPath = stringFromUnknown(selection.projectPath);
+  const cwd = stringFromUnknown(selection.cwd);
+  const requestedProjectRoot = explicitProjectPath
+    ? await findProjectRoot(explicitProjectPath)
+    : !explicitInstanceId && cwd
+      ? await findProjectRoot(cwd)
+      : null;
+
+  if (explicitProjectPath && !requestedProjectRoot) {
+    throw new Error(
+      `No project.godot found at or above ${resolve(explicitProjectPath)}.`
+    );
+  }
+
+  const instances = await listEngineInstances(
+    options.nowMs ?? Date.now(),
+    summerDir
+  );
+  let candidates = instances;
+  if (explicitInstanceId) {
+    candidates = candidates.filter(
+      (instance) => instance.instanceId === explicitInstanceId
+    );
+  }
+  if (requestedProjectRoot) {
+    const canonicalRoot = await canonicalPath(requestedProjectRoot);
+    candidates = candidates.filter(
+      (instance) => instance.resourceRoot === canonicalRoot
+    );
+  }
+
+  if (explicitInstanceId || requestedProjectRoot) {
+    if (candidates.length === 1) {
+      return connectionForInstance(candidates[0], {
+        ...selection,
+        projectPath: requestedProjectRoot ?? selection.projectPath,
+      });
+    }
+    if (candidates.length > 1) {
+      throw new Error(
+        `More than one Summer editor matches this project. Select one with \`summer mcp --instance <id>\`:\n${formatInstances(candidates)}`
+      );
+    }
+    const canUseLegacyForInferredProject =
+      instances.length === 0 &&
+      !explicitInstanceId &&
+      !explicitProjectPath &&
+      Boolean(requestedProjectRoot);
+    if (!canUseLegacyForInferredProject) {
+      const target = explicitInstanceId
+        ? `instance ${explicitInstanceId}`
+        : `project ${requestedProjectRoot}`;
+      throw new Error(
+        `No running Summer editor matches ${target}. Open that project in Summer Engine and retry.`
+      );
+    }
+  }
+
+  if (instances.length === 1) {
+    return connectionForInstance(instances[0], selection);
+  }
+  if (instances.length > 1) {
+    throw new Error(
+      "Multiple Summer editors are running and this agent is not inside a Summer project. " +
+      "Start the agent from the project directory, or pass `summer mcp --project <path>`.\n" +
+      formatInstances(instances)
+    );
+  }
+
+  const [port, token] = await Promise.all([
+    getApiPort(summerDir),
+    getApiToken(summerDir),
+  ]);
+  if (!token) {
+    throw new Error(
+      "Summer Engine is not running (no api-token found). Open Summer Engine first."
+    );
+  }
+  const health = await checkEngineHealth(port);
+  if (!health) {
+    throw new Error(
+      `Summer Engine is not responding on port ${port}. Make sure it's open.`
+    );
+  }
+  return {
+    port,
+    token,
+    health,
+    selection: null,
+    source: "legacy",
+  };
 }
 
 export interface EngineHealth {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -2,6 +2,7 @@ import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { EngineApiClient } from "../lib/api-client.js";
+import type { EngineSelection } from "../lib/engine.js";
 import { registerSceneTools } from "./tools/scene-tools.js";
 import { registerDebugTools } from "./tools/debug-tools.js";
 import { registerVisualTools } from "./tools/visual-tools.js";
@@ -43,6 +44,14 @@ async function probeBootDrift(): Promise<void> {
 }
 
 let cachedClient: EngineApiClient | null = null;
+let engineSelection: EngineSelection | undefined;
+
+export function configureMcpEngineSelection(
+  selection?: EngineSelection
+): void {
+  engineSelection = selection ? { ...selection } : undefined;
+  cachedClient = null;
+}
 
 export async function getClient(): Promise<EngineApiClient> {
   if (cachedClient) {
@@ -59,12 +68,17 @@ export async function getClient(): Promise<EngineApiClient> {
   }
 
   try {
-    cachedClient = await EngineApiClient.connect();
+    cachedClient = await EngineApiClient.connect(engineSelection);
     return cachedClient;
-  } catch {
+  } catch (error) {
     cachedClient = null;
+    const reason =
+      error instanceof Error
+        ? error.message
+        : "Summer Engine is not running.";
     throw new Error(
-      "Summer Engine is not running. Open it first, or run: npx summer-engine run\n" +
+      reason + "\n" +
+        "Open the intended project in Summer Engine, or run: npx summer-engine run\n" +
         "Note: only tools that touch the local project need the engine. Cloud tools " +
         "(summer_generate_*, summer_search_assets, summer_list_my_assets, summer_get_asset, " +
         "summer_check_job) work right now without it — they only need 'npx summer-engine login'."
@@ -239,13 +253,33 @@ function installResultSizeLogger(server: {
   return () => registeredToolCount;
 }
 
-export async function startMcpServer(): Promise<void> {
+export interface StartMcpServerOptions {
+  projectPath?: string;
+  instanceId?: string;
+  cwd?: string;
+}
+
+export async function startMcpServer(
+  options: StartMcpServerOptions = {}
+): Promise<void> {
+  configureMcpEngineSelection({
+    instanceId:
+      options.instanceId ?? process.env.SUMMER_ENGINE_INSTANCE_ID,
+    projectPath:
+      options.projectPath ?? process.env.SUMMER_ENGINE_PROJECT,
+    cwd: options.cwd ?? process.cwd(),
+  });
   installMcpProcessDiagnostics();
   appendMcpLogEvent("mcp:start", {
     version,
     pid: process.pid,
     node: process.version,
     cwd: process.cwd(),
+    selection: {
+      instanceId: options.instanceId ? "explicit" : undefined,
+      projectPath: options.projectPath ? "explicit" : undefined,
+      cwd: options.cwd ?? process.cwd(),
+    },
   });
 
   const server = new McpServer({


### PR DESCRIPTION
## Summary
- discover all live Summer editor instance registry entries
- bind MCP by explicit instance, explicit project, or the agents current project directory
- reject ambiguous unscoped routing and validate editor identity before using credentials
- retain legacy api-port/api-token compatibility when no live registry is available

## Verification
- npm run build
- npm test: 36 files, 362 tests passed
- live smoke with two controller-launched editors on ports 6550 and 6551 selected the correct project from each cwd and rejected an unrelated cwd

Companion engine mirror PR: https://github.com/SummerEngine/SummerEngine/pull/37