### PR TITLE
Sync public source with summer-engine 2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,25 @@
 
 All notable changes to summer-engine will be documented here. Following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [2.8.1] — 2026-08-18 — "Scene mutations work again on engine 0.5.60+"
+
+### Added
+- `summer_get_scene_tree` accepts optional `depth` and `limit` params (engine defaults: depth 2, limit 200 — a 102-node scene silently truncated to 61 nodes at the defaults). The engine only honors them on scene-targeted reads, so the tool resolves the current scene path first when needed and says so when it can't. `summer_get_project_context` accepts an optional `settingsPrefix` and, without one, trims `project.data.entries` to a curated prefix set (application/, display/, input/, physics/, rendering/) instead of returning the full ~188KB settings dump — the payload declares the trim via `settingsTruncated`/`totalSettings`/`settingsHint`.
+- `summer_screenshot` scene captures accept `nodePath` (frame a specific node, honest `node_not_found` failure) and new framing directions `back`/`left`/`right`; captions report the resolved framing and any render retries. Requires engine 0.5.62+ to take effect — older engines silently ignore the new fields.
+- `summer_get_diagnostics` returns a prioritized bounded view (errors first, then warnings, capped info tail) with honest suppression counters, plus `includeAll: true` for the untrimmed payload. Severity + recency + caps only — no noise-pattern matching.
+- `scripts/compat-smoke.sh`: a latest-MCP × candidate-engine release gate that drives the real built MCP server against a live engine and fails loudly on batch-contract incompatibilities (the class of bug that broke 2.7.0–2.8.0 × engine 0.5.60+). Run it before every engine release and every npm publish.
+
+### Fixed
+- `summer_create_scene` no longer uses the destructive temporary-template strategy (open current scene → delete its children → save-as → restore). It now writes a minimal `.tscn` through the identity-bound engine `WriteFile` with a create-only guard, never touches the open scene, verifies by reading the file back, and gained a `rootType` param (Node3D/Node2D/Control). `allow_temporary_scene_mutation` remains accepted as a deprecated no-op.
+- **Scene mutations were completely broken against engine 0.5.60/0.5.61.** The engine now requires `SaveScene`, `InstantiateScene`, `ReplaceNode`, `SimulateInput`, and the `Run*`/`Import*`/`Git*` ops to travel as their own single-op request, and rejects any multi-op batch containing one of them wholesale (`failure_reason: "unsupported_transport"`). Since 2.7.0 appended `SaveScene` to every mutation batch, every `summer_add_node`/`summer_set_prop`/`summer_batch`/`summer_create_scene` call was rejected before anything executed. Mutation batches are now automatically split into sequential requests around single-only ops; all receipts are preserved and merged, and a mutation that applied followed by a save that failed is reported honestly (including which ops already applied and which were not sent).
+- Engine failures no longer hide the precise rejection. `extractOpError` previously returned a generic `"Engine operation failed (terminalState: failed)"` without inspecting `results[]`; it now surfaces the failed op's own error and `failure_reason` (envelope or per-op, either spelling), rendered as JSON when a classifier is present so agents can key on `failure_reason` reliably.
+- `save_frame` is documented with its required `name` argument everywhere (`save_frame()` with no args is a probe script error), plus the deferred scene-mount pattern that avoids black frames.
+- SimulateInput guidance corrected: it IS reachable over MCP/CLI as a single op against the running game (`failure_reason: "not_running"`/`"unsupported"` are the real failure modes); `"unsupported_transport"` only means it was batched with other ops. The previous claim that it needs the in-editor bridge on every build was stale.
+- The scene-preview synthetic-camera note no longer claims the scene has no camera — the engine always synthesizes the preview camera; `sceneHasCamera` is the authoritative signal and keeps its own warning.
+- `summer login` waits 15 minutes on one session id (was 2) with periodic reminders, covering first-time account creation + email confirmation. The gateway never expires a pending session, so the single id stays valid the whole window.
+- Removed the stale "Engine mirror only" banner from the README (it shipped to npm and the public repo, and its claims were wrong).
+
+## [2.8.0] — 2026-08-17 — "Multi-editor MCP routing"
 
 ### Added
 - MCP discovers every live Summer editor through `~/.summer/instances/` and automatically binds local tools to the editor whose project contains the agent's current working directory.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Summer Engine: the AI game engine
 
-> **Engine mirror only.** This directory is intentionally marked `private` and must never be published to npm. Review and reconcile changes into [SummerEngine/summer-engine-agent](https://github.com/SummerEngine/summer-engine-agent), which is the only npm release source.
-
 Build real 2D and 3D Summer games with Summer Engine, the Summer SDK, and
 GDScript. The agent layer can help author code and scenes, but creators remain
 in control of changes and release decisions. Local export support depends on
@@ -324,7 +322,7 @@ summer_batch ops:[{op:"RunVerification", probe_source:"…", max_seconds:20}]
                                       → {ok, results, frames, out_dir}
 ```
 
-Unlike `--headless`, that instance has a real renderer, so `save_frame()` writes an actual image. Probe API: `report()` / `save_frame()` / `dump_tree()` / `press()` / `key()` / `finish()`. **`press()` and `key()` are coroutines — `await` them.** Every project scaffolded by `summer create` ships a working example at `tests/autopilot/`.
+Unlike `--headless`, that instance has a real renderer, so `save_frame("name")` writes an actual image (the name argument is required). Probe API: `report(name, value)` / `save_frame(name)` / `dump_tree()` / `press(action)` / `key(keycode)` / `finish()`. **`press()` and `key()` are coroutines — `await` them.** Every project scaffolded by `summer create` ships a working example at `tests/autopilot/`.
 
 `SimulateInput` is **not** reachable from MCP or the CLI, on any build. It needs the in-editor chat bridge's async reply channel; every queued caller is answered `{ok:false, failure_reason:"unsupported_transport"}`. Use the probe.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "summer-engine",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "summer-engine",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "summer-engine",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Local Summer CLI and MCP server for Summer Engine. Install and run the engine, connect Claude Code, Cursor, Codex, Gemini, and other agents, and build real games with bundled skills, hooks, and plugins.",
   "keywords": [
     "summer-engine",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,25 @@
+# summer-cli scripts
+
+- `smoke-test.sh` — CLI-level smoke tests (unit tests, command basics, template creation). Engine optional; engine-dependent checks are skipped when no editor is running.
+- `compat-smoke.sh` (+ `compat-smoke.mjs` helper) — latest-MCP x candidate-engine compatibility gate. Engine REQUIRED. See below.
+
+## Release gate: compat-smoke
+
+```
+bash tools/summer-cli/scripts/compat-smoke.sh [--project <path>]
+```
+
+**Run it before every engine release AND before every npm publish of summer-engine.** Both sides of the MCP <-> engine HTTP contract are unit-tested only against mocks (MCP tests mock the engine; engine tests mock the client), so a contract drift between them is invisible to CI. That is exactly how MCP 2.7.0-2.8.0 shipped appending `SaveScene` into multi-op batches while engine 0.5.60+ rejects such batches wholesale (`failure_reason: "unsupported_transport"`) — every scene mutation via MCP was broken for weeks with all tests green.
+
+What it does:
+
+1. Builds the local CLI (`npm run build`) and starts the REAL built MCP server (`dist/bin/summer.js mcp`) over stdio, driving the actual `summer_*` tool handlers — including the scene-tools op-splitting logic — against the running engine. No hand-rolled HTTP.
+2. Exercises: `summer_get_project_context`; `summer_add_node` verified via scene state; `summer_batch` with a mixed op list including an `InstantiateScene` (asserts the single-op split lands as 3 sequential requests against the real engine); a `RunVerification` probe using `save_frame("compat")`; `SimulateInput` as a single op (`failure_reason: "not_running"` counts as a pass when no game is running).
+3. Any `unsupported_transport` on a mutation path exits 1 with a loud message naming the incompatible CLI x engine version pair.
+4. Cleans up the nodes and the throwaway prefab scene it created. Completes in well under 2 minutes.
+
+Precondition: a running Summer editor with a **scratch** project open (it mutates the open/main scene). Auto-detected via the `~/.summer/instances` registry, falling back to the legacy `~/.summer/api-port`/`api-token` files. `--project <path>` is required only when several editors are running.
+
+Exit codes: `0` compatible, `1` incompatibility or failure, `2` precondition not met (no running editor / no scene).
+
+Env: `SUMMER_COMPAT_SKIP_BUILD=1` reuses an existing `dist/` build; `SUMMER_COMPAT_TIMEOUT_MS` overrides the global watchdog (default 115000 ms).

--- a/scripts/compat-smoke.mjs
+++ b/scripts/compat-smoke.mjs
@@ -1,0 +1,578 @@
+#!/usr/bin/env node
+/**
+ * compat-smoke.mjs — latest-MCP x candidate-engine compatibility smoke gate.
+ *
+ * WHY THIS EXISTS: summer-engine MCP 2.7.0-2.8.0 appended SaveScene into
+ * multi-op batches while engine 0.5.60+ rejects such batches WHOLESALE
+ * (failure_reason "unsupported_transport"/"skipped"). Every scene mutation via
+ * MCP was broken for weeks and no test caught it, because MCP unit tests mock
+ * the engine and engine tests mock the client. This gate runs the REAL built
+ * MCP server (dist/bin/summer.js mcp, stdio JSON-RPC) against the REAL running
+ * engine, so the op-composition layer (scene-tools chunking/splitting) is
+ * exercised end-to-end.
+ *
+ * PRECONDITION: a running Summer editor with a SCRATCH project open (the gate
+ * mutates the open scene, then cleans up after itself). Auto-detected via the
+ * ~/.summer/instances registry (same registry lib/engine.ts uses), falling
+ * back to the legacy ~/.summer/api-port + api-token files.
+ *
+ * Invoked by scripts/compat-smoke.sh — run that, not this, so the CLI is
+ * freshly built first.
+ *
+ * Exit codes: 0 = compatible, 1 = incompatibility / failure, 2 = precondition
+ * not met (no running editor / no scene).
+ */
+
+import { spawn } from "node:child_process";
+import { readdir, readFile, realpath, unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createInterface } from "node:readline";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_DIR = resolve(__dirname, "..");
+// Hardcoded to match lib/store.ts getSummerDir(): the spawned MCP server always
+// reads ~/.summer, so preflight must look in exactly the same place.
+const SUMMER_DIR = join(homedir(), ".summer");
+const INSTANCE_STALE_MS = 180_000;
+const GLOBAL_BUDGET_MS = Number(process.env.SUMMER_COMPAT_TIMEOUT_MS || 115_000);
+const RUN_ID = Date.now().toString(36);
+
+// ---------------------------------------------------------------------------
+// tiny arg parse: [--project <path>]
+// ---------------------------------------------------------------------------
+let projectArg = null;
+{
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--project") {
+      projectArg = args[++i];
+      if (!projectArg) fatal(2, "--project requires a path");
+    } else if (args[i] === "--help" || args[i] === "-h") {
+      console.log("Usage: bash tools/summer-cli/scripts/compat-smoke.sh [--project <path>]");
+      process.exit(0);
+    } else {
+      fatal(2, `Unknown argument: ${args[i]}`);
+    }
+  }
+}
+
+function fatal(code, msg) {
+  console.error(`\n[compat-smoke] ${msg}`);
+  process.exit(code);
+}
+
+const bold = (s) => `\x1b[1m${s}\x1b[0m`;
+const green = (s) => `\x1b[32m${s}\x1b[0m`;
+const red = (s) => `\x1b[31m${s}\x1b[0m`;
+const yellow = (s) => `\x1b[33m${s}\x1b[0m`;
+
+// ---------------------------------------------------------------------------
+// Preflight: detect a running Summer editor (registry first, then legacy files)
+// ---------------------------------------------------------------------------
+function pidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === "EPERM";
+  }
+}
+
+async function canonical(p) {
+  try {
+    return await realpath(resolve(p));
+  } catch {
+    return resolve(p);
+  }
+}
+
+async function listLiveInstances() {
+  const dir = join(SUMMER_DIR, "instances");
+  let entries;
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const live = [];
+  for (const name of entries) {
+    if (!name.endsWith(".json")) continue;
+    try {
+      const parsed = JSON.parse(await readFile(join(dir, name), "utf-8"));
+      if (parsed.schemaVersion !== 1) continue;
+      if (!parsed.port || !parsed.token || !parsed.resourceRoot) continue;
+      if (!pidAlive(parsed.pid)) continue;
+      if (Date.now() - parsed.heartbeatAt * 1000 > INSTANCE_STALE_MS) continue;
+      parsed.resourceRoot = await canonical(parsed.resourceRoot);
+      live.push(parsed);
+    } catch {
+      // one malformed entry must not hide other editors
+    }
+  }
+  return live;
+}
+
+async function fetchHealth(port) {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/health`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data && data.ok === true && data.engine === "summer" ? data : null;
+  } catch {
+    return null;
+  }
+}
+
+async function preflight() {
+  let instances = await listLiveInstances();
+  if (projectArg) {
+    const root = await canonical(projectArg);
+    instances = instances.filter((i) => i.resourceRoot === root);
+  }
+  if (instances.length > 1) {
+    fatal(
+      2,
+      "PRECONDITION NOT MET: multiple Summer editors are running. Pass --project <path> to pick the scratch project.\n" +
+        instances.map((i) => `  - ${i.projectName ?? "?"} (${i.resourceRoot})`).join("\n")
+    );
+  }
+  if (instances.length === 1) {
+    const inst = instances[0];
+    const health = await fetchHealth(inst.port);
+    if (!health) {
+      fatal(2, `PRECONDITION NOT MET: registry instance ${inst.instanceId} is not responding on port ${inst.port}.`);
+    }
+    return { port: inst.port, engineVersion: health.version ?? inst.engineVersion, resourceRoot: inst.resourceRoot, source: "registry" };
+  }
+
+  // Legacy single-editor files
+  let port = 6550;
+  try {
+    port = parseInt((await readFile(join(SUMMER_DIR, "api-port"), "utf-8")).trim(), 10) || 6550;
+  } catch {
+    // default
+  }
+  let token = null;
+  try {
+    token = (await readFile(join(SUMMER_DIR, "api-token"), "utf-8")).trim() || null;
+  } catch {
+    // absent
+  }
+  if (!token) {
+    fatal(
+      2,
+      "PRECONDITION NOT MET: no running Summer editor found (empty instances registry, no ~/.summer/api-token).\n" +
+        "Open a SCRATCH project in Summer Engine (e.g. `summer create empty /tmp/compat-scratch && summer run`), then re-run."
+    );
+  }
+  const health = await fetchHealth(port);
+  if (!health) {
+    fatal(2, `PRECONDITION NOT MET: ~/.summer credentials exist but no engine responds on port ${port}.`);
+  }
+  return { port, engineVersion: health.version, resourceRoot: null, source: "legacy" };
+}
+
+// ---------------------------------------------------------------------------
+// Minimal MCP stdio client (newline-delimited JSON-RPC, no dependencies)
+// ---------------------------------------------------------------------------
+class McpStdioClient {
+  constructor(cmd, args) {
+    this.child = spawn(cmd, args, {
+      cwd: CLI_DIR,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.pending = new Map();
+    this.nextId = 1;
+    this.stderrTail = [];
+    this.exited = false;
+
+    createInterface({ input: this.child.stdout }).on("line", (line) => {
+      let msg;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        return;
+      }
+      if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
+        const entry = this.pending.get(msg.id);
+        if (entry) {
+          this.pending.delete(msg.id);
+          if (msg.error) entry.reject(new Error(`MCP error: ${JSON.stringify(msg.error)}`));
+          else entry.resolve(msg.result);
+        }
+      } else if (msg.id !== undefined && msg.method) {
+        // Server-initiated request (e.g. ping) — answer minimally.
+        this.send({ jsonrpc: "2.0", id: msg.id, result: {} });
+      }
+      // Notifications from the server are ignored.
+    });
+    createInterface({ input: this.child.stderr }).on("line", (line) => {
+      this.stderrTail.push(line);
+      if (this.stderrTail.length > 40) this.stderrTail.shift();
+    });
+    this.child.on("exit", (code) => {
+      this.exited = true;
+      for (const [, entry] of this.pending) {
+        entry.reject(new Error(`MCP server exited (code ${code}) before responding`));
+      }
+      this.pending.clear();
+    });
+  }
+
+  send(msg) {
+    this.child.stdin.write(JSON.stringify(msg) + "\n");
+  }
+
+  request(method, params, timeoutMs = 60_000) {
+    if (this.exited) return Promise.reject(new Error("MCP server already exited"));
+    const id = this.nextId++;
+    return new Promise((resolvePromise, rejectPromise) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        rejectPromise(new Error(`Timed out after ${timeoutMs}ms waiting for ${method}`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: (v) => {
+          clearTimeout(timer);
+          resolvePromise(v);
+        },
+        reject: (e) => {
+          clearTimeout(timer);
+          rejectPromise(e);
+        },
+      });
+      this.send({ jsonrpc: "2.0", id, method, params });
+    });
+  }
+
+  async initialize() {
+    const result = await this.request(
+      "initialize",
+      {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "summer-compat-smoke", version: "1.0.0" },
+      },
+      20_000
+    );
+    this.send({ jsonrpc: "2.0", method: "notifications/initialized" });
+    return result;
+  }
+
+  /** tools/call → { isError, text, json } (json = parsed text when parseable). */
+  async callTool(name, args, timeoutMs = 60_000) {
+    const result = await this.request("tools/call", { name, arguments: args ?? {} }, timeoutMs);
+    const text = (result.content ?? [])
+      .filter((c) => c && c.type === "text" && typeof c.text === "string")
+      .map((c) => c.text)
+      .join("\n");
+    let json = null;
+    try {
+      json = JSON.parse(text);
+    } catch {
+      // Non-JSON tool text is fine.
+    }
+    return { isError: result.isError === true, text, json };
+  }
+
+  kill() {
+    try {
+      this.child.kill("SIGTERM");
+    } catch {
+      // already gone
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Result bookkeeping
+// ---------------------------------------------------------------------------
+const steps = [];
+let cliVersion = "unknown";
+let engineVersion = "unknown";
+let incompatibility = null;
+
+function recordPass(name, detail = "") {
+  steps.push({ name, status: "PASS", detail });
+  console.log(`  ${green("PASS")}: ${name}${detail ? ` — ${detail}` : ""}`);
+}
+function recordFail(name, detail) {
+  steps.push({ name, status: "FAIL", detail });
+  console.log(`  ${red("FAIL")}: ${name} — ${detail}`);
+}
+
+function failureReasonOf(res) {
+  if (res.json && typeof res.json.failure_reason === "string") return res.json.failure_reason;
+  const m = res.text.match(/"failure_reason"\s*:\s*"([^"]+)"/);
+  return m ? m[1] : null;
+}
+
+/** Any unsupported_transport (or the batch gate's "skipped") on a mutation-path
+ *  step is THE incompatibility this gate exists to catch. */
+function checkTransportIncompatibility(stepName, res) {
+  if (/unsupported_transport/.test(res.text)) {
+    incompatibility =
+      `Engine rejected the MCP op dispatch with failure_reason "unsupported_transport" during "${stepName}". ` +
+      `This is the MCP-batch-composition x engine-single-op-dispatch incompatibility ` +
+      `(summer-engine CLI ${cliVersion} vs engine ${engineVersion}): the engine refuses the batch shape the MCP is sending. ` +
+      `DO NOT RELEASE this engine/CLI pair.`;
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  console.log(bold("\nSummer MCP x Engine compatibility smoke gate"));
+  console.log("=============================================\n");
+
+  try {
+    cliVersion = JSON.parse(await readFile(join(CLI_DIR, "package.json"), "utf-8")).version;
+  } catch {
+    // keep "unknown"
+  }
+
+  const engine = await preflight();
+  engineVersion = engine.engineVersion ?? "unknown";
+  console.log(`Engine detected: version ${engineVersion} on port ${engine.port} (${engine.source})`);
+  console.log(`CLI under test:  summer-engine ${cliVersion} (local build)\n`);
+
+  const mcpArgs = [join(CLI_DIR, "dist/bin/summer.js"), "mcp"];
+  if (projectArg) mcpArgs.push("--project", projectArg);
+  const client = new McpStdioClient(process.execPath, mcpArgs);
+
+  const watchdog = setTimeout(() => {
+    console.error(red(`\nGLOBAL TIMEOUT: gate exceeded ${GLOBAL_BUDGET_MS}ms budget.`));
+    printSummary();
+    client.kill();
+    process.exit(1);
+  }, GLOBAL_BUDGET_MS);
+
+  // Names of everything we create, for cleanup.
+  const NODE_A = `CompatSmokeNode_${RUN_ID}`;
+  const NODE_B = `CompatSmokeBatch_${RUN_ID}`;
+  const NODE_INST = `CompatSmokeInst_${RUN_ID}`;
+  const PREFAB_RES = `res://compat_smoke_prefab_${RUN_ID}.tscn`;
+  const createdNodes = [];
+  let prefabCreated = false;
+  let scenePath = null;
+  let projectDiskPath = engine.resourceRoot ?? (projectArg ? await canonical(projectArg) : null);
+
+  async function cleanup() {
+    // Best effort — never let cleanup mask the verdict.
+    for (const node of createdNodes) {
+      try {
+        await client.callTool("summer_remove_node", { scenePath, path: `./${node}` }, 30_000);
+      } catch {
+        // ignore
+      }
+    }
+    if (prefabCreated && projectDiskPath) {
+      const rel = PREFAB_RES.replace("res://", "");
+      for (const p of [join(projectDiskPath, rel), join(projectDiskPath, `${rel}.uid`)]) {
+        try {
+          await unlink(p);
+        } catch {
+          // absent is fine
+        }
+      }
+    }
+  }
+
+  try {
+    // -- Handshake ----------------------------------------------------------
+    try {
+      const init = await client.initialize();
+      recordPass("MCP stdio handshake", `server ${init?.serverInfo?.name ?? "?"} v${init?.serverInfo?.version ?? "?"}`);
+    } catch (err) {
+      recordFail("MCP stdio handshake", String(err.message ?? err));
+      throw new Error("handshake failed");
+    }
+
+    // -- 1. summer_get_project_context ---------------------------------------
+    {
+      const res = await client.callTool("summer_get_project_context", {}, 30_000);
+      if (res.isError) {
+        recordFail("summer_get_project_context", res.text.slice(0, 300));
+        throw new Error("cannot bind to project");
+      }
+      scenePath = res.json?.currentScene || res.json?.mainScene || null;
+      if (!scenePath) {
+        clearTimeout(watchdog);
+        client.kill();
+        fatal(2, "PRECONDITION NOT MET: the open project reports no currentScene and no mainScene. Open a scratch project with a main scene.");
+      }
+      if (!projectDiskPath && typeof res.json?.projectPath === "string") {
+        projectDiskPath = res.json.projectPath;
+      }
+      const healthVersion = res.json?.health?.version;
+      if (typeof healthVersion === "string") engineVersion = healthVersion;
+      recordPass("summer_get_project_context", `bound to ${scenePath} (engine ${engineVersion})`);
+    }
+
+    // -- 2. summer_write_file: create the prefab used by InstantiateScene ----
+    {
+      const content = '[gd_scene format=3]\n\n[node name="CompatSmokePrefab" type="Node3D"]\n';
+      const res = await client.callTool(
+        "summer_write_file",
+        { path: PREFAB_RES, content, create_only: true },
+        45_000
+      );
+      if (checkTransportIncompatibility("summer_write_file", res) || res.isError) {
+        recordFail("summer_write_file (prefab create)", res.text.slice(0, 300));
+        throw new Error("prefab creation failed");
+      }
+      prefabCreated = true;
+      recordPass("summer_write_file (prefab create)", PREFAB_RES);
+    }
+
+    // -- 3. summer_add_node + verify via scene state --------------------------
+    {
+      const res = await client.callTool(
+        "summer_add_node",
+        { scenePath, parent: ".", type: "Node3D", name: NODE_A },
+        45_000
+      );
+      if (checkTransportIncompatibility("summer_add_node", res) || res.isError) {
+        recordFail("summer_add_node", res.text.slice(0, 300));
+        throw new Error("add_node failed");
+      }
+      createdNodes.push(NODE_A);
+
+      const tree = await client.callTool("summer_get_scene_tree", { scenePath }, 30_000);
+      if (tree.isError || !tree.text.includes(NODE_A)) {
+        recordFail("summer_add_node verified in scene state", tree.isError ? tree.text.slice(0, 300) : `node ${NODE_A} not found in tree`);
+        throw new Error("add_node not observable in scene state");
+      }
+      recordPass("summer_add_node + scene-state verification", `${NODE_A} present in ${scenePath}`);
+    }
+
+    // -- 4. summer_batch with a mixed op list incl. InstantiateScene ----------
+    // Chunking contract: [AddNode, SetProp] batch together; InstantiateScene
+    // must travel alone; the appended SaveScene travels alone => 3 requests.
+    {
+      const res = await client.callTool(
+        "summer_batch",
+        {
+          scenePath,
+          ops: [
+            { op: "AddNode", parent: ".", type: "Node3D", name: NODE_B },
+            { op: "SetProp", path: `./${NODE_B}`, key: "position", value: "Vector3(0, 1, 0)" },
+            { op: "InstantiateScene", parent: ".", scene: PREFAB_RES, name: NODE_INST },
+          ],
+        },
+        60_000
+      );
+      if (checkTransportIncompatibility("summer_batch (mixed ops + InstantiateScene)", res) || res.isError) {
+        recordFail("summer_batch (mixed ops + InstantiateScene)", res.text.slice(0, 400));
+        throw new Error("mixed batch failed");
+      }
+      createdNodes.push(NODE_B, NODE_INST);
+
+      const requests = res.json?.requests;
+      if (requests !== 3) {
+        recordFail(
+          "summer_batch single-op split",
+          `expected the op list to be split into 3 sequential requests ([AddNode,SetProp] / [InstantiateScene] / [SaveScene]), receipt reports requests=${requests ?? "absent"}`
+        );
+        throw new Error("split contract not exercised");
+      }
+      const tree = await client.callTool("summer_get_scene_tree", { scenePath }, 30_000);
+      if (tree.isError || !tree.text.includes(NODE_B) || !tree.text.includes(NODE_INST)) {
+        recordFail("summer_batch results verified in scene state", `expected ${NODE_B} and ${NODE_INST} in tree`);
+        throw new Error("batch results not observable");
+      }
+      recordPass("summer_batch mixed ops + single-op split", `split into ${requests} requests; ${NODE_B} and ${NODE_INST} present`);
+    }
+
+    // -- 5. RunVerification probe with save_frame("compat") -------------------
+    {
+      const probe = [
+        "extends SummerProbeBase",
+        "func _ready() -> void:",
+        "\tawait super._ready()",
+        "\tawait get_tree().process_frame",
+        '\treport("compat", true)',
+        '\tsave_frame("compat")',
+        "\tfinish()",
+      ].join("\n");
+      const res = await client.callTool(
+        "summer_batch",
+        { ops: [{ op: "RunVerification", probe_source: probe, max_seconds: 15 }] },
+        60_000
+      );
+      if (checkTransportIncompatibility("RunVerification", res) || res.isError) {
+        recordFail("RunVerification probe (save_frame compat)", `${failureReasonOf(res) ?? ""} ${res.text.slice(0, 300)}`);
+        throw new Error("RunVerification failed");
+      }
+      recordPass("RunVerification probe (save_frame compat)");
+    }
+
+    // -- 6. SimulateInput as a single op --------------------------------------
+    {
+      const res = await client.callTool(
+        "summer_batch",
+        { ops: [{ op: "SimulateInput", type: "action", action: "ui_accept", pressed: true }] },
+        30_000
+      );
+      const reason = failureReasonOf(res);
+      if (checkTransportIncompatibility("SimulateInput", res)) {
+        recordFail("SimulateInput single-op dispatch", `failure_reason unsupported_transport — engine refuses the single-op SimulateInput request shape`);
+        throw new Error("SimulateInput transport incompatibility");
+      }
+      if (!res.isError) {
+        recordPass("SimulateInput single-op dispatch", "accepted (game running)");
+      } else if (reason === "not_running") {
+        recordPass("SimulateInput single-op dispatch", 'expected structured failure "not_running" (no game running) — transport OK');
+      } else {
+        recordFail("SimulateInput single-op dispatch", `unexpected failure (reason=${reason ?? "none"}): ${res.text.slice(0, 300)}`);
+        throw new Error("SimulateInput unexpected failure");
+      }
+    }
+  } catch {
+    // The failing step already recorded itself; fall through to cleanup+summary.
+  }
+
+  console.log("\nCleaning up created nodes and prefab...");
+  await cleanup();
+  clearTimeout(watchdog);
+  client.kill();
+
+  const ok = printSummary(client);
+  process.exit(ok ? 0 : 1);
+}
+
+function printSummary(client) {
+  const failed = steps.filter((s) => s.status === "FAIL");
+  console.log("\n=============================================");
+  console.log(bold("Compat smoke summary"));
+  for (const s of steps) {
+    console.log(`  ${s.status === "PASS" ? green("PASS") : red("FAIL")}  ${s.name}`);
+  }
+  if (incompatibility) {
+    console.log("\n" + red(bold("!!! MCP x ENGINE INCOMPATIBILITY DETECTED !!!")));
+    console.log(red(incompatibility));
+  }
+  if (failed.length > 0) {
+    console.log(red(`\nRESULT: FAIL (${failed.length} failing step${failed.length === 1 ? "" : "s"}) — CLI ${cliVersion} x engine ${engineVersion}`));
+    if (client && client.stderrTail.length) {
+      console.log(yellow("\nLast MCP server stderr lines:"));
+      for (const line of client.stderrTail.slice(-10)) console.log(`  ${line}`);
+    }
+    return false;
+  }
+  console.log(green(`\nRESULT: PASS — CLI ${cliVersion} is compatible with engine ${engineVersion}`));
+  return true;
+}
+
+main().catch((err) => {
+  console.error(red(`\n[compat-smoke] Unexpected error: ${err?.stack ?? err}`));
+  process.exit(1);
+});

--- a/scripts/compat-smoke.sh
+++ b/scripts/compat-smoke.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# compat-smoke.sh — latest-MCP x candidate-engine compatibility smoke gate.
+#
+# Builds the LOCAL summer-cli, starts its real MCP server over stdio, and
+# drives the real summer_* tool handlers against the RUNNING Summer editor —
+# exercising the actual op-composition layer (scene-tools batch splitting)
+# that unit tests on both sides mock away. See compat-smoke.mjs for the
+# incident this guards against (MCP 2.7.0-2.8.0 x engine 0.5.60+ batch
+# wholesale rejection).
+#
+# PRECONDITION: a running Summer editor with a SCRATCH project open. The gate
+# mutates that project's open/main scene (and creates a throwaway prefab
+# .tscn), then cleans up after itself. Do not point it at a project you care
+# about. e.g.:
+#   summer create empty /tmp/compat-scratch && open it in Summer Engine
+#
+# Usage:
+#   bash tools/summer-cli/scripts/compat-smoke.sh [--project <path>]
+#
+# --project is required only when more than one Summer editor is running.
+# Env: SUMMER_COMPAT_SKIP_BUILD=1 skips npm run build (dist/ must exist).
+#
+# Exit codes: 0 compatible, 1 incompatibility/failure, 2 precondition not met.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLI_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$CLI_DIR"
+
+if [ "${SUMMER_COMPAT_SKIP_BUILD:-0}" = "1" ]; then
+  if [ ! -f "dist/bin/summer.js" ]; then
+    echo "[compat-smoke] SUMMER_COMPAT_SKIP_BUILD=1 but dist/bin/summer.js is missing. Run 'npm run build' first." >&2
+    exit 1
+  fi
+  echo "[compat-smoke] Skipping build (SUMMER_COMPAT_SKIP_BUILD=1)."
+else
+  echo "[compat-smoke] Building local CLI (npm run build)..."
+  npm run build
+fi
+
+exec node "$SCRIPT_DIR/compat-smoke.mjs" "$@"

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -10,7 +10,13 @@ import {
 import { getCreatorApiUrl, getGatewayUrl } from "../lib/config.js";
 
 const POLL_INTERVAL_MS = 2000;
-const POLL_TIMEOUT_MS = 120000;
+// One generous window on ONE session id. First-time users may need to create an
+// account and confirm an email before they can approve the CLI. The gateway
+// never expires a pending session (the completed payload waits under this id
+// for pickup), so the worst mistake would be rotating ids mid-wait — the user
+// would approve the original browser tab while we poll a different session.
+const POLL_TIMEOUT_MS = 900000;
+const HEARTBEAT_MS = 30000;
 
 export const loginCommand = new Command("login")
   .description("Sign in to Summer Engine via your browser")
@@ -162,10 +168,19 @@ export async function runLogin(
 
   const pollUrl = `${gatewayUrl}/api/auth/cli-login?session=${encodeURIComponent(sessionId)}`;
   const startTime = deps.now();
+  let lastHeartbeat = startTime;
   let lastError: string | null = null;
 
   while (deps.now() - startTime < POLL_TIMEOUT_MS) {
     await deps.sleep(POLL_INTERVAL_MS);
+
+    if (deps.now() - lastHeartbeat >= HEARTBEAT_MS) {
+      lastHeartbeat = deps.now();
+      deps.log(
+        'Still waiting — finish signing in (or creating your account) in the browser, then click "Yes, Sign In". Same link: ' +
+          loginUrl
+      );
+    }
 
     try {
       const res = await deps.fetch(pollUrl, {
@@ -213,6 +228,6 @@ export async function runLogin(
   }
 
   throw new Error(
-    `Login timed out after 120 seconds.${lastError ? ` Last error: ${lastError}` : ""} Recovery: run "summer login" again, complete "Yes, Sign In" in the browser, and return to the terminal within two minutes.`
+    `Login timed out after ${Math.round(POLL_TIMEOUT_MS / 60000)} minutes.${lastError ? ` Last error: ${lastError}` : ""} Recovery: run "summer login" again and complete "Yes, Sign In" in the browser tab it opens.`
   );
 }

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -45,6 +45,15 @@ export type EngineSnapshot = {
   sceneHasCamera?: boolean;
   sceneHadLight?: boolean;
   usedSyntheticCamera?: boolean;
+  /** Scene-preview only: the framing the engine actually rendered with
+   *  ("auto" resolves to "iso"). */
+  framing?: string;
+  /** Scene-preview only: path (relative to the scene root) of the node the
+   *  camera framed when nodePath was given. */
+  framedNode?: string;
+  /** Scene-preview only: how many blank-readback retries the engine needed
+   *  before the capture produced a non-blank frame (0 = clean first read). */
+  renderRetries?: number;
   /** Set true when the bound projectIdHash no longer matches the engine's live
    *  health hash at capture time — the frame may be from the WRONG project
    *  (item 4, client-side drift check). */
@@ -67,6 +76,9 @@ type SnapshotPayload = Record<string, unknown> & {
   scene_has_camera?: boolean;
   scene_had_light?: boolean;
   used_synthetic_camera?: boolean;
+  framing?: string;
+  framed_node?: string;
+  render_retries?: number;
 };
 
 type EngineTargetIdentity = {
@@ -486,15 +498,34 @@ export class EngineApiClient {
     return this.request("GET", `/api/state/read-file?${query.toString()}`);
   }
 
-  async getSceneState(scenePath?: string): Promise<unknown> {
-    const query = scenePath
-      ? `?scene=${encodeURIComponent(scenePath)}`
-      : "";
+  async getSceneState(
+    scenePath?: string,
+    options?: { depth?: number; limit?: number }
+  ): Promise<unknown> {
+    // depth/limit only take effect on targeted (scene=) reads: the engine
+    // routes those through the live command queue and forwards every query
+    // param into StateProvider::scene_state (tool_net_thread.cpp
+    // _parse_state_args). An UNtargeted read is answered from a pre-published
+    // snapshot built with the defaults (depth 2, limit 200) and its query
+    // params are ignored — callers who need depth/limit must pass scenePath
+    // (summer_get_scene_tree resolves the current scene path for this).
+    const parts: string[] = [];
+    if (scenePath) parts.push(`scene=${encodeURIComponent(scenePath)}`);
+    if (options?.depth !== undefined) parts.push(`depth=${options.depth}`);
+    if (options?.limit !== undefined) parts.push(`limit=${options.limit}`);
+    const query = parts.length ? `?${parts.join("&")}` : "";
     return this.request("GET", `/api/state/scene${query}`);
   }
 
-  async getProjectState(): Promise<unknown> {
-    return this.request("GET", "/api/state/project");
+  async getProjectState(prefix?: string): Promise<unknown> {
+    // ?prefix= is sent for forward-compatibility, but current engine builds
+    // IGNORE it: /api/state/project is always served from the snapshot, which
+    // is published with empty args (local_api_server.cpp
+    // _maybe_publish_snapshot), so StateProvider::project_state never sees the
+    // query. Callers that need a prefix subset must also filter client-side
+    // (summer_get_project_context does).
+    const query = prefix ? `?prefix=${encodeURIComponent(prefix)}` : "";
+    return this.request("GET", `/api/state/project${query}`);
   }
 
   async getDiagnostics(): Promise<unknown> {
@@ -668,6 +699,9 @@ export class EngineApiClient {
       sceneHasCamera: boolFrom(payload.scene_has_camera),
       sceneHadLight: boolFrom(payload.scene_had_light),
       usedSyntheticCamera: boolFrom(payload.used_synthetic_camera),
+      framing: stringFrom(payload.framing),
+      framedNode: stringFrom(payload.framed_node),
+      renderRetries: numberFrom(payload.render_retries),
       projectMismatch,
       metadata: withoutImageData(payload),
     };
@@ -720,13 +754,18 @@ export class EngineApiClient {
    * Offscreen scene render via the `ScenePreview` op over /api/ops (no game
    * boot; physics/animations are static). Mirrors the web previewScene op input
    * (snapshot-tools.ts): { op:'ScenePreview', scene_path?, framing?, size?,
-   * node_path? } — scene_path optional, engine defaults to the open scene. The
-   * result carries image_base64 + mime (+ width/height) plus the P4.3 confession
-   * fields (scene_has_camera / scene_had_light / used_synthetic_camera).
+   * node? } — scene_path optional, engine defaults to the open scene. `node` is
+   * the canonical focus-node arg (the engine also accepts the legacy web wire
+   * name `node_path`); an unresolvable node fails with failure_reason
+   * "node_not_found". framing "auto" is an alias of "iso"; the engine also
+   * accepts "top"/"front"/"back"/"left"/"right" and echoes the resolved framing.
+   * The result carries image_base64 + mime (+ width/height) plus the P4.3
+   * confession fields (scene_has_camera / scene_had_light /
+   * used_synthetic_camera) and framing / framed_node / render_retries.
    */
   async scenePreview(input?: {
     scenePath?: string;
-    framing?: "auto" | "top" | "front" | "iso";
+    framing?: "auto" | "iso" | "top" | "front" | "back" | "left" | "right";
     size?: [number, number];
     nodePath?: string;
   }): Promise<EngineSnapshot> {
@@ -735,7 +774,7 @@ export class EngineApiClient {
     if (trimmed && trimmed !== "." && trimmed !== "./") opInput.scene_path = trimmed;
     if (input?.framing) opInput.framing = input.framing;
     if (input?.size) opInput.size = input.size;
-    if (input?.nodePath) opInput.node_path = input.nodePath;
+    if (input?.nodePath) opInput.node = input.nodePath;
 
     let response: unknown;
     try {

--- a/src/mcp/tools/debug-tools.test.ts
+++ b/src/mcp/tools/debug-tools.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../server.js", () => ({
+  getClient: vi.fn(),
+  resetClient: vi.fn(),
+}));
+
+vi.mock("../../lib/telemetry.js", () => ({
+  recordMcpSession: vi.fn(),
+}));
+
+import { getClient } from "../server.js";
+import { prioritizeDiagnostics, registerDebugTools } from "./debug-tools.js";
+
+type RegisteredTool = {
+  name: string;
+  handler: (args: Record<string, unknown>) => Promise<unknown>;
+};
+
+function tools(): RegisteredTool[] {
+  const registered: RegisteredTool[] = [];
+  registerDebugTools({
+    tool(
+      name: string,
+      _description: string,
+      _schema: Record<string, unknown>,
+      handler: (args: Record<string, unknown>) => Promise<unknown>
+    ) {
+      registered.push({ name, handler });
+      return { name };
+    },
+  } as never);
+  return registered;
+}
+
+function tool(registered: RegisteredTool[], name: string): RegisteredTool {
+  const found = registered.find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`Missing tool ${name}`);
+  return found;
+}
+
+function text(result: unknown): string {
+  const envelope = result as { content?: Array<{ text?: string }> };
+  return envelope.content?.[0]?.text ?? "";
+}
+
+function consoleMessage(type: string, textBody: string): Record<string, unknown> {
+  return { text: textBody, count: 1, type };
+}
+
+/** Engine-shaped diagnostics payload: newest-first messages, noisy baseline. */
+function enginePayload(): Record<string, unknown> {
+  return {
+    ok: true,
+    data: {
+      console: {
+        errors: 1,
+        warnings: 1,
+        std: 40,
+        editor: 2,
+        total: 43,
+        returned: 43,
+        messages: [
+          consoleMessage("std", "noise-0 (newest)"),
+          consoleMessage("error", "task-specific failure"),
+          ...Array.from({ length: 20 }, (_, i) => consoleMessage("std", `noise-${i + 1}`)),
+          consoleMessage("warning", "one warning"),
+          ...Array.from({ length: 20 }, (_, i) => consoleMessage("editor", `editor-noise-${i}`)),
+        ],
+      },
+      debugger: {
+        errors: 2,
+        warnings: 60,
+        session_active: true,
+        is_breaked: false,
+        errors_data: [
+          { severity: "error", error: "boom-newest" },
+          { severity: "error", error: "boom-older" },
+        ],
+        warnings_data: Array.from({ length: 50 }, (_, i) => ({
+          severity: "warning",
+          error: `warn-${i}`,
+        })),
+      },
+      script_errors: { errors: [], count: 0 },
+      total_errors: 3,
+      total_warnings: 61,
+      has_issues: true,
+      guidance: "Errors present.",
+    },
+    provenance: { source: "diagnostics" },
+    appliedThroughSeq: 7,
+    snapshotSeq: 9,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("prioritizeDiagnostics", () => {
+  it("reorders console messages errors-first and caps the info tail at 10", () => {
+    const shaped = prioritizeDiagnostics(enginePayload()) as {
+      data: {
+        console: { messages: Array<{ type: string; text: string }>; returned: number; total: number };
+      };
+      _view: Record<string, unknown>;
+    };
+    const messages = shaped.data.console.messages;
+    expect(messages[0]).toMatchObject({ type: "error", text: "task-specific failure" });
+    expect(messages[1]).toMatchObject({ type: "warning", text: "one warning" });
+    const tail = messages.slice(2);
+    expect(tail).toHaveLength(10);
+    expect(tail.every((m) => m.type === "std" || m.type === "editor")).toBe(true);
+    // Newest-first order preserved within the noise bucket — the kept tail is
+    // the most recent noise, not the oldest.
+    expect(tail[0].text).toBe("noise-0 (newest)");
+    expect(shaped.data.console.returned).toBe(12);
+    // Counts remain the engine truth.
+    expect(shaped.data.console.total).toBe(43);
+  });
+
+  it("keeps debugger errors untouched and caps warnings_data at 20 newest", () => {
+    const shaped = prioritizeDiagnostics(enginePayload()) as {
+      data: {
+        debugger: {
+          errors: number;
+          warnings: number;
+          errors_data: unknown[];
+          warnings_data: Array<{ error: string }>;
+        };
+      };
+    };
+    expect(shaped.data.debugger.errors_data).toHaveLength(2);
+    expect(shaped.data.debugger.warnings_data).toHaveLength(20);
+    expect(shaped.data.debugger.warnings_data[0].error).toBe("warn-0");
+    // True counts are not rewritten by the trim.
+    expect(shaped.data.debugger.errors).toBe(2);
+    expect(shaped.data.debugger.warnings).toBe(60);
+  });
+
+  it("reports honest counters and an includeAll hint in _view", () => {
+    const shaped = prioritizeDiagnostics(enginePayload()) as {
+      _view: {
+        mode: string;
+        totalConsole: number;
+        shownConsole: number;
+        suppressedInfo: number;
+        totalDebugger: number;
+        shownDebugger: number;
+        suppressedDebuggerWarnings: number;
+        hint: string;
+      };
+    };
+    expect(shaped._view.mode).toBe("prioritized");
+    expect(shaped._view.totalConsole).toBe(43);
+    expect(shaped._view.shownConsole).toBe(12);
+    // 41 noise messages in the array, 10 kept.
+    expect(shaped._view.suppressedInfo).toBe(31);
+    expect(shaped._view.totalDebugger).toBe(62);
+    expect(shaped._view.shownDebugger).toBe(22);
+    expect(shaped._view.suppressedDebuggerWarnings).toBe(30);
+    expect(shaped._view.hint).toContain("includeAll");
+  });
+
+  it("does not mutate the input payload", () => {
+    const payload = enginePayload();
+    const before = JSON.stringify(payload);
+    prioritizeDiagnostics(payload);
+    expect(JSON.stringify(payload)).toBe(before);
+  });
+
+  it("passes through payloads without a data dict unchanged", () => {
+    expect(prioritizeDiagnostics(null)).toBeNull();
+    expect(prioritizeDiagnostics("nope")).toBe("nope");
+    const noData = { ok: false, error: "engine main thread unresponsive" };
+    expect(prioritizeDiagnostics(noData)).toBe(noData);
+  });
+
+  it("tolerates missing console/debugger sections", () => {
+    const shaped = prioritizeDiagnostics({ ok: true, data: { total_errors: 0 } }) as {
+      data: Record<string, unknown>;
+      _view: { totalConsole: number; totalDebugger: number };
+    };
+    expect(shaped.data.total_errors).toBe(0);
+    expect(shaped._view.totalConsole).toBe(0);
+    expect(shaped._view.totalDebugger).toBe(0);
+  });
+
+  it("keeps every error and warning even when they outnumber the noise cap", () => {
+    const payload = enginePayload();
+    const data = payload.data as Record<string, unknown>;
+    const consoleData = data.console as Record<string, unknown>;
+    consoleData.messages = Array.from({ length: 30 }, (_, i) =>
+      consoleMessage(i % 2 === 0 ? "error" : "warning", `sev-${i}`)
+    );
+    const shaped = prioritizeDiagnostics(payload) as {
+      data: { console: { messages: unknown[] } };
+      _view: { suppressedInfo: number };
+    };
+    expect(shaped.data.console.messages).toHaveLength(30);
+    expect(shaped._view.suppressedInfo).toBe(0);
+  });
+});
+
+describe("summer_get_diagnostics tool", () => {
+  it("returns the prioritized view by default", async () => {
+    const getDiagnostics = vi.fn().mockResolvedValue(enginePayload());
+    vi.mocked(getClient).mockResolvedValue({ getDiagnostics } as never);
+
+    const result = await tool(tools(), "summer_get_diagnostics").handler({});
+    const body = JSON.parse(text(result)) as {
+      data: { console: { messages: Array<{ type: string }> } };
+      _view: { mode: string };
+    };
+    expect(getDiagnostics).toHaveBeenCalledTimes(1);
+    expect(body._view.mode).toBe("prioritized");
+    expect(body.data.console.messages[0].type).toBe("error");
+  });
+
+  it("returns the untrimmed engine payload with includeAll: true", async () => {
+    const payload = enginePayload();
+    const getDiagnostics = vi.fn().mockResolvedValue(payload);
+    vi.mocked(getClient).mockResolvedValue({ getDiagnostics } as never);
+
+    const result = await tool(tools(), "summer_get_diagnostics").handler({
+      includeAll: true,
+    });
+    const body = JSON.parse(text(result)) as {
+      data: { console: { messages: unknown[] }; debugger: { warnings_data: unknown[] } };
+      _view?: unknown;
+    };
+    expect(body._view).toBeUndefined();
+    expect(body.data.console.messages).toHaveLength(43);
+    expect(body.data.debugger.warnings_data).toHaveLength(50);
+  });
+});

--- a/src/mcp/tools/debug-tools.ts
+++ b/src/mcp/tools/debug-tools.ts
@@ -4,6 +4,94 @@ import { withEngine } from "./with-engine.js";
 import { shapeEngineLogResponse } from "../../lib/log-filters.js";
 import { createDebugReportArtifact } from "../../lib/debug-report.js";
 
+// summer_get_diagnostics view shaping. The engine serves /api/state/diagnostics
+// from a pre-published snapshot (empty args — query params are NOT forwarded on
+// that route), so trimming has to happen here. The snapshot defaults bury
+// task-specific failures under baseline info noise (50 console messages, up to
+// 100 debugger entries); this reorders by severity and caps ONLY the
+// low-severity bodies. All counts stay intact and honest. No pattern-matching
+// against specific noise strings — severity + recency + caps only.
+const CONSOLE_NOISE_TAIL_CAP = 10;
+const DEBUGGER_WARNING_CAP = 20;
+
+/**
+ * Prioritized, bounded view of the engine diagnostics payload:
+ * - console.messages reordered: errors first, then warnings, then a capped tail
+ *   of info/std/editor noise (engine order is newest-first; that order is
+ *   preserved within each severity bucket, so the kept tail is the most recent).
+ * - debugger.errors_data untouched; debugger.warnings_data capped to the most
+ *   recent DEBUGGER_WARNING_CAP entries (engine emits newest-first).
+ * - a `_view` block with honest counters and a hint pointing at includeAll.
+ * Shape-tolerant: anything unexpected passes through unchanged.
+ * Exported for unit tests.
+ */
+export function prioritizeDiagnostics(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object") return payload;
+  const root = payload as Record<string, unknown>;
+  if (!root.data || typeof root.data !== "object") return payload;
+  const data = root.data as Record<string, unknown>;
+  const shapedData: Record<string, unknown> = { ...data };
+
+  let totalConsole = 0;
+  let shownConsole = 0;
+  let suppressedInfo = 0;
+  if (data.console && typeof data.console === "object") {
+    const c = data.console as Record<string, unknown>;
+    totalConsole = typeof c.total === "number" ? c.total : 0;
+    if (Array.isArray(c.messages)) {
+      const errors: unknown[] = [];
+      const warnings: unknown[] = [];
+      const rest: unknown[] = [];
+      for (const m of c.messages) {
+        const type =
+          m && typeof m === "object" ? (m as Record<string, unknown>).type : undefined;
+        if (type === "error") errors.push(m);
+        else if (type === "warning") warnings.push(m);
+        else rest.push(m);
+      }
+      const keptRest = rest.slice(0, CONSOLE_NOISE_TAIL_CAP);
+      suppressedInfo = rest.length - keptRest.length;
+      const messages = [...errors, ...warnings, ...keptRest];
+      shownConsole = messages.length;
+      shapedData.console = { ...c, messages, returned: messages.length };
+    }
+  }
+
+  let totalDebugger = 0;
+  let shownDebugger = 0;
+  let suppressedDebuggerWarnings = 0;
+  if (data.debugger && typeof data.debugger === "object") {
+    const g = data.debugger as Record<string, unknown>;
+    totalDebugger =
+      (typeof g.errors === "number" ? g.errors : 0) +
+      (typeof g.warnings === "number" ? g.warnings : 0);
+    const errorsData = Array.isArray(g.errors_data) ? g.errors_data : [];
+    if (Array.isArray(g.warnings_data)) {
+      const keptWarnings = g.warnings_data.slice(0, DEBUGGER_WARNING_CAP);
+      suppressedDebuggerWarnings = g.warnings_data.length - keptWarnings.length;
+      shownDebugger = errorsData.length + keptWarnings.length;
+      shapedData.debugger = { ...g, warnings_data: keptWarnings };
+    } else {
+      shownDebugger = errorsData.length;
+    }
+  }
+
+  return {
+    ...root,
+    data: shapedData,
+    _view: {
+      mode: "prioritized",
+      totalConsole,
+      shownConsole,
+      suppressedInfo,
+      totalDebugger,
+      shownDebugger,
+      suppressedDebuggerWarnings,
+      hint: "All counts are complete; only low-severity message bodies were trimmed. Re-call with includeAll: true for the untrimmed payload, or use summer_get_console / summer_get_debugger_warnings for targeted reads.",
+    },
+  };
+}
+
 export function registerDebugTools(server: McpServer): void {
   server.tool(
     "summer_get_diagnostics",
@@ -11,13 +99,27 @@ export function registerDebugTools(server: McpServer): void {
 
 ALWAYS call this FIRST before diving into summer_get_console or summer_get_debugger_errors. It tells you where to look.
 
+By default the response is a prioritized view: errors first, then warnings, then a small capped tail of recent info/std noise. Counts (console totals, debugger totals) are always complete — only low-severity message bodies are trimmed, and a "_view" block reports exactly what was suppressed. Pass includeAll: true for the full untrimmed engine payload.
+
 Typical workflow after making changes:
 1. summer_get_diagnostics — are there issues?
 2. If errors: summer_get_console or summer_get_debugger_errors for details
 3. Fix the issues
 4. summer_get_diagnostics again to verify`,
-    {},
-    async () => withEngine(async (client) => client.getDiagnostics())
+    {
+      includeAll: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "Return the full engine diagnostics payload untrimmed (no severity reordering, no info-noise cap)."
+        ),
+    },
+    async ({ includeAll }) =>
+      withEngine(async (client) => {
+        const raw = await client.getDiagnostics();
+        return includeAll ? raw : prioritizeDiagnostics(raw);
+      })
   );
 
   server.tool(

--- a/src/mcp/tools/project-tools.test.ts
+++ b/src/mcp/tools/project-tools.test.ts
@@ -172,6 +172,161 @@ priority: locked
     });
   });
 
+  it("trims project settings to curated prefixes and declares the trim", async () => {
+    vi.mocked(getClient).mockResolvedValue({
+      health: vi.fn(async () => ({ ok: true })),
+      getProjectState: vi.fn(async () => ({
+        ok: true,
+        data: {
+          entries: [
+            { key: "application/run/main_scene", value: "res://main.tscn" },
+            { key: "display/window/size/viewport_width", value: 1920 },
+            { key: "audio/buses/default_bus_layout", value: "res://bus.tres" },
+            { key: "editor/naming/scene_name_casing", value: 2 },
+          ],
+        },
+      })),
+      getSceneState: vi.fn(async () => ({ ok: true, data: {} })),
+      rebind: vi.fn(async () => "test-project-hash"),
+    } as never);
+
+    const { server, tools } = createFakeServer();
+    registerProjectTools(server as never);
+
+    const contextTool = getTool(tools, "summer_get_project_context");
+    const body = parseToolResult(await contextTool.handler({}));
+    const data = (body.project as { data: Record<string, unknown> }).data;
+    const keys = (data.entries as Array<{ key: string }>).map((entry) => entry.key);
+
+    expect(keys).toEqual([
+      "application/run/main_scene",
+      "display/window/size/viewport_width",
+    ]);
+    expect(data.settingsTruncated).toBe(true);
+    expect(data.totalSettings).toBe(4);
+    expect(data.returnedSettings).toBe(2);
+    expect(data.settingsHint).toContain("settingsPrefix");
+    expect(data.settingsPrefixesIncluded).toContain("application/");
+    // Derived context still reads the untrimmed state.
+    expect(body.mainScene).toBe("res://main.tscn");
+  });
+
+  it("threads settingsPrefix to the engine and filters settings client-side", async () => {
+    const getProjectState = vi.fn(async () => ({
+      ok: true,
+      data: {
+        entries: [
+          { key: "application/run/main_scene", value: "res://main.tscn" },
+          { key: "audio/buses/default_bus_layout", value: "res://bus.tres" },
+        ],
+      },
+    }));
+    vi.mocked(getClient).mockResolvedValue({
+      health: vi.fn(async () => ({ ok: true })),
+      getProjectState,
+      getSceneState: vi.fn(async () => ({ ok: true, data: {} })),
+      rebind: vi.fn(async () => "test-project-hash"),
+    } as never);
+
+    const { server, tools } = createFakeServer();
+    registerProjectTools(server as never);
+
+    const contextTool = getTool(tools, "summer_get_project_context");
+    const body = parseToolResult(await contextTool.handler({ settingsPrefix: "audio/" }));
+
+    // The prefix rides the query string for forward-compat, but current
+    // engines ignore it — so the client-side filter must hold on its own.
+    expect(getProjectState).toHaveBeenCalledWith("audio/");
+    const data = (body.project as { data: Record<string, unknown> }).data;
+    expect(data.entries).toEqual([
+      { key: "audio/buses/default_bus_layout", value: "res://bus.tres" },
+    ]);
+    expect(data.settingsPrefix).toBe("audio/");
+    expect(data.settingsTruncated).toBe(true);
+    expect(data.totalSettings).toBe(2);
+    // Derived context still reads the untrimmed state.
+    expect(body.mainScene).toBe("res://main.tscn");
+  });
+
+  it("reads the scene tree untargeted when no depth/limit are requested", async () => {
+    const getSceneState = vi.fn(async () => ({ ok: true, data: { name: "Root" } }));
+    vi.mocked(getClient).mockResolvedValue({ getSceneState } as never);
+
+    const { server, tools } = createFakeServer();
+    registerProjectTools(server as never);
+
+    const treeTool = getTool(tools, "summer_get_scene_tree");
+    await treeTool.handler({});
+
+    expect(getSceneState).toHaveBeenCalledTimes(1);
+    expect(getSceneState.mock.calls[0]).toEqual([undefined]);
+  });
+
+  it("resolves the current scene and re-reads targeted when depth/limit are passed", async () => {
+    // Engine contract: depth/limit only apply to scene=-targeted reads; the
+    // untargeted route serves a default-args snapshot and drops query params.
+    const getSceneState = vi.fn(
+      async (scenePath?: string, options?: { depth?: number; limit?: number }) => {
+        if (!scenePath) {
+          return {
+            ok: true,
+            data: { name: "Root" },
+            provenance: { scenePath: "res://main.tscn" },
+          };
+        }
+        return { ok: true, data: { name: "Root", visited: 102 }, requested: { scenePath, options } };
+      }
+    );
+    vi.mocked(getClient).mockResolvedValue({ getSceneState } as never);
+
+    const { server, tools } = createFakeServer();
+    registerProjectTools(server as never);
+
+    const treeTool = getTool(tools, "summer_get_scene_tree");
+    const body = parseToolResult(await treeTool.handler({ depth: 10, limit: 500 }));
+
+    expect(getSceneState).toHaveBeenCalledTimes(2);
+    expect(getSceneState.mock.calls[0]).toEqual([]);
+    expect(getSceneState.mock.calls[1]).toEqual([
+      "res://main.tscn",
+      { depth: 10, limit: 500 },
+    ]);
+    expect(body.requested).toEqual({
+      scenePath: "res://main.tscn",
+      options: { depth: 10, limit: 500 },
+    });
+  });
+
+  it("passes depth/limit directly when scenePath is explicit", async () => {
+    const getSceneState = vi.fn(async () => ({ ok: true, data: { name: "Root" } }));
+    vi.mocked(getClient).mockResolvedValue({ getSceneState } as never);
+
+    const { server, tools } = createFakeServer();
+    registerProjectTools(server as never);
+
+    const treeTool = getTool(tools, "summer_get_scene_tree");
+    await treeTool.handler({ scenePath: "res://level.tscn", depth: 6 });
+
+    expect(getSceneState).toHaveBeenCalledTimes(1);
+    expect(getSceneState.mock.calls[0]).toEqual(["res://level.tscn", { depth: 6, limit: undefined }]);
+  });
+
+  it("reports honestly when depth/limit cannot be applied without a resolvable scene", async () => {
+    const getSceneState = vi.fn(async () => ({ ok: true, data: { name: "Root" } }));
+    vi.mocked(getClient).mockResolvedValue({ getSceneState } as never);
+
+    const { server, tools } = createFakeServer();
+    registerProjectTools(server as never);
+
+    const treeTool = getTool(tools, "summer_get_scene_tree");
+    const body = parseToolResult(await treeTool.handler({ depth: 10 }));
+
+    expect(getSceneState).toHaveBeenCalledTimes(1);
+    expect(body.depthLimitApplied).toBe(false);
+    expect(body.note).toContain("IGNORED");
+    expect(body.data).toEqual({ name: "Root" });
+  });
+
   it("teaches agents to read relevant memory before project work", async () => {
     const { server, tools } = createFakeServer();
     registerProjectTools(server as never);

--- a/src/mcp/tools/project-tools.ts
+++ b/src/mcp/tools/project-tools.ts
@@ -119,6 +119,69 @@ function getCurrentScene(
   );
 }
 
+function getScenePathFromSceneState(sceneState: unknown): string | null {
+  const root = asRecord(sceneState);
+  return (
+    pickString(asRecord(root?.provenance), ["scenePath", "scene_path"]) ??
+    pickString(asRecord(root?.data), ["scenePath", "scene_path"]) ??
+    null
+  );
+}
+
+/** Default prefix set kept in summer_get_project_context when no settingsPrefix
+ *  is given. The full settings dump measured 188KB (~47k tokens) on a real
+ *  project; these prefixes cover what agents actually key on (main scene,
+ *  window size, input actions, physics, renderer). */
+const CONTEXT_SETTINGS_PREFIXES = [
+  "application/",
+  "display/",
+  "input/",
+  "physics/",
+  "rendering/",
+] as const;
+
+/**
+ * Bound the project-state payload. The engine ignores ?prefix= on
+ * /api/state/project (snapshot-served with empty args — see
+ * ApiClient.getProjectState), so ALL filtering here is client-side:
+ * - settingsPrefix given: keep only entries under that prefix.
+ * - no prefix: keep only the curated CONTEXT_SETTINGS_PREFIXES.
+ * Trimming is always declared in the payload (settingsTruncated /
+ * totalSettings / hint); everything outside data.entries is preserved.
+ */
+function trimProjectSettings(projectState: unknown, settingsPrefix?: string): unknown {
+  const root = asRecord(projectState);
+  const data = asRecord(root?.data);
+  const entries = data?.entries;
+  if (!root || !data || !Array.isArray(entries)) return projectState;
+
+  const keyOf = (entry: unknown): string | null => stringFrom(asRecord(entry)?.key);
+  const kept = settingsPrefix
+    ? entries.filter((entry) => keyOf(entry)?.startsWith(settingsPrefix) ?? false)
+    : entries.filter((entry) => {
+        const key = keyOf(entry);
+        return key !== null && CONTEXT_SETTINGS_PREFIXES.some((p) => key.startsWith(p));
+      });
+
+  return {
+    ...root,
+    data: {
+      ...data,
+      entries: kept,
+      settingsTruncated: kept.length < entries.length,
+      totalSettings: entries.length,
+      returnedSettings: kept.length,
+      ...(settingsPrefix
+        ? { settingsPrefix }
+        : {
+            settingsPrefixesIncluded: [...CONTEXT_SETTINGS_PREFIXES],
+            settingsHint:
+              "Settings were trimmed to the curated prefixes above to bound payload size. Pass settingsPrefix (e.g. 'audio/' or 'layer_names/') to read another settings group.",
+          }),
+    },
+  };
+}
+
 export function registerProjectTools(server: McpServer): void {
   server.tool(
     "summer_start_game_task",
@@ -226,12 +289,12 @@ anti-patterns, and recovery steps.`,
                   "summer_stop  -> stop when runtime verification is finished; editor scene mutations are not categorically blocked by a running game, but an existing game instance may need a restart to observe them",
                 ],
                 "4_interactive": [
-                  "To prove input-driven behavior (does jump/move/shoot actually work), use RunVerification. It is the ONLY interactive route available to MCP, and it is a real one — do NOT hand this rung to the user.",
+                  "To prove input-driven behavior (does jump/move/shoot actually work), prefer RunVerification — a scripted, repeatable probe. SimulateInput is also reachable as a single op against the RUNNING game (see rawOpsViaBatch); do NOT hand this rung to the user while either route works.",
                   "RunVerification: spawn a hidden, disposable game instance that runs a GDScript probe (press inputs, read state, save frames) and dies — never touches the user's editor. Returns results.json + frames. Send it as a raw op through summer_batch (see rawOpsViaBatch).",
-                  "Unlike the editor's own --headless mode, the verify instance renders REAL PIXELS, so save_frame() writes a real image and Performance.TIME_FPS reports a real number.",
+                  "Unlike the editor's own --headless mode, the verify instance renders REAL PIXELS, so save_frame('name') writes a real image and Performance.TIME_FPS reports a real number. save_frame REQUIRES a name argument — save_frame() with no args is a script error (probe fails).",
+                  "Mount probe scenes DEFERRED: get_tree().root.add_child.call_deferred(instance); await get_tree().process_frame; await settle(). A direct add_child during _ready can hit the parent-busy guard and 'succeed' while capturing a black frame.",
                   "press()/key() are COROUTINES — 'await press(\"move_right\", 500)' or the hold never elapses and the input does nothing.",
                   "Assert on physics-frame-derived state (positions after N 'await get_tree().physics_frame'), which is reproducible. press(hold_ms) waits on wall clock, so distance-travelled jitters run to run — assert 'moved more than X', never an exact value.",
-                  "SimulateInput is NOT reachable from MCP — see rawOpsViaBatch. Do not attempt it as a fallback.",
                 ],
               },
               // HONESTY — mirror the in-product agent's vision rules. A capture is
@@ -265,8 +328,9 @@ anti-patterns, and recovery steps.`,
               // engine ops that have no dedicated tool are still reachable.
               rawOpsViaBatch: [
                 "summer_batch runs an array of raw engine ops in one undo group; each op is passed through untouched, so newer engine ops with no dedicated tool are still callable.",
-                "RunVerification (hidden probe instance): summer_batch ops:[{op:'RunVerification', probe_source:'<gdscript>', max_seconds:20}]. probe_source extends SummerProbeBase and uses report()/save_frame()/press()/key()/finish(); returns {ok, results, frames, out_dir} or {ok:false, failure_reason: spawn_failed|timeout|bad_args|no_project|probe_not_node}.",
-                "SimulateInput is NOT reachable this way, on any engine build. It needs the in-editor chat bridge's async reply channel; every queued caller (MCP, CLI) is answered with {ok:false, failure_reason:'unsupported_transport'}. Use RunVerification's press()/key() instead.",
+                "RunVerification (hidden probe instance): summer_batch ops:[{op:'RunVerification', probe_source:'<gdscript>', max_seconds:20}]. probe_source extends SummerProbeBase and uses report(name, value)/save_frame(name)/press(action)/key(keycode)/finish(); returns {ok, results, frames, out_dir} or {ok:false, failure_reason: spawn_failed|timeout|bad_args|no_project|probe_not_node}. save_frame REQUIRES a name argument.",
+                "SimulateInput (drive the RUNNING game — summer_play first): summer_batch ops:[{op:'SimulateInput', type:'action', action:'jump', pressed:true}], sent ALONE as the only op. failure_reason 'not_running' = start the game first; 'unsupported' = the running game build predates the handler — use RunVerification instead.",
+                "SINGLE-OP CONTRACT: the engine rejects any multi-op batch containing SaveScene, InstantiateScene, ReplaceNode, SimulateInput, ViewportSnapshot, GameSnapshot, Run*/Import* or Git* ops (failure_reason 'unsupported_transport', nothing executes). summer_batch splits these into sequential requests for you; when composing raw batches keep them as their own call anyway.",
                 "WriteFile and ReplaceText are rejected here by design — use summer_write_file / summer_replace_text so project identity, content guards and same-file ordering are enforced.",
                 "You do not need an engine op to run a shell command: your own host already has a shell. The engine binary that runs project scripts is at OS.get_executable_path() (on macOS, /Applications/Summer.app/Contents/MacOS/Summer); see the summer-cli headless-scripting skill.",
                 "These are runtime ops, not scene mutations — the batch undo group is a harmless no-op for them.",
@@ -279,7 +343,7 @@ anti-patterns, and recovery steps.`,
                 "If a mutation is rejected with identity_mismatch: the engine switched projects — call summer_get_project_context to rebind (only if you meant to follow it), then retry.",
                 "If a guarded file mutation is rejected with content mismatch: call summer_read_file again, review the new content, and retry with its new sha256 only if the edit is still valid.",
                 "If a run op returns 'unsupported' / an unknown-op error: this engine build predates it — fall back to summer_play + summer_get_debugger_errors.",
-                "If SimulateInput returns 'unsupported_transport': that is permanent for MCP, not a build gap. Rewrite the check as a RunVerification probe.",
+                "If any op returns 'unsupported_transport': it was batched with other ops. Resend it as the ONLY op in the request (nothing from the rejected batch was applied).",
               ],
               debugging: [
                 "Set SUMMER_MCP_DEBUG=1 in the MCP server's environment to log a structured stderr line per tool call (tool, ok, durationMs, terminalState, errorClass, failureReason, retried, boundProjectIdHash). With the flag OFF, only failures are logged. Use it to see exactly which op failed and why.",
@@ -302,23 +366,39 @@ anti-patterns, and recovery steps.`,
 - main scene path from project settings
 - lightweight .summer project memory summary when project path is available
 
-Use this first in every fresh chat to avoid guessing scene filenames or editing the wrong scene.`,
-    {},
-    async () =>
+Use this first in every fresh chat to avoid guessing scene filenames or editing the wrong scene.
+
+Project settings in project.data.entries are trimmed to a curated prefix set
+(application/, display/, input/, physics/, rendering/) to bound payload size —
+the untrimmed dump can exceed 45k tokens. The payload declares the trim
+(settingsTruncated, totalSettings, settingsPrefixesIncluded). Pass
+settingsPrefix to read a specific settings group (e.g. 'audio/') instead.`,
+    {
+      settingsPrefix: z
+        .string()
+        .optional()
+        .describe(
+          "Only return project settings whose key starts with this prefix, e.g. 'audio/' or 'application/config/'. Omit for the curated default set."
+        ),
+    },
+    async ({ settingsPrefix }) =>
       withEngine(async (client) => {
-        const [health, projectState, sceneState] = await Promise.all([
+        const [health, fullProjectState, sceneState] = await Promise.all([
           client.health(),
-          client.getProjectState(),
+          client.getProjectState(settingsPrefix),
           client.getSceneState().catch((err) => ({
             ok: false,
             error: err instanceof Error ? err.message : String(err),
           })),
         ]);
+        // Derived fields read the UNtrimmed state so a narrow settingsPrefix
+        // cannot hide mainScene/projectPath from the context summary.
+        const projectState = trimProjectSettings(fullProjectState, settingsPrefix);
 
-        const projectPath = getProjectPath(projectState, health);
-        const projectName = getProjectName(projectState, health);
-        const mainScene = getMainScene(projectState);
-        const currentScene = getCurrentScene(projectState, sceneState, health);
+        const projectPath = getProjectPath(fullProjectState, health);
+        const projectName = getProjectName(fullProjectState, health);
+        const mainScene = getMainScene(fullProjectState);
+        const currentScene = getCurrentScene(fullProjectState, sceneState, health);
 
         // This tool is the deliberate (re)bind point: capture the currently-open
         // project as the one this session's mutations are pinned to. After an
@@ -415,11 +495,51 @@ Example: Bind jump to Space and W:
     `Get a scene tree. Pass scenePath to read that exact in-memory/open scene;
 omit it only when you intentionally want the currently visible editor scene.
 Scene mutations load their explicit target, so a follow-up targeted read does
-not require OpenScene.`,
+not require OpenScene.
+
+The engine defaults to depth 2 and limit 200 nodes and SILENTLY truncates
+deeper hierarchies (the response then carries truncated: true and a visited
+count lower than the real node count). Pass an explicit depth (e.g. 10) to
+read a full tree — a 102-node scene returns only 61 nodes at the defaults.`,
     {
       scenePath: z.string().optional().describe("Exact res:// scene path to inspect"),
+      depth: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Maximum tree depth to walk. Engine default is 2 — pass a larger value for deep hierarchies."),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Maximum number of nodes to return. Engine default is 200."),
     },
-    async ({ scenePath }) => withEngine(async (client) => client.getSceneState(scenePath))
+    async ({ scenePath, depth, limit }) =>
+      withEngine(async (client) => {
+        if (depth === undefined && limit === undefined) {
+          return client.getSceneState(scenePath);
+        }
+        // The engine honors depth/limit ONLY on targeted (scene=) reads; an
+        // untargeted read is served from a pre-published snapshot built with
+        // the defaults, and its query params are dropped. Resolve the current
+        // scene path first so depth/limit actually take effect.
+        let target = scenePath;
+        if (!target) {
+          const snapshot = await client.getSceneState();
+          target = getScenePathFromSceneState(snapshot) ?? undefined;
+          if (!target) {
+            const record = asRecord(snapshot);
+            return {
+              ...(record ?? { snapshot }),
+              depthLimitApplied: false,
+              note: "depth/limit were IGNORED: the current scene path could not be resolved, and the engine only honors depth/limit on scene-targeted reads. Pass scenePath explicitly to apply them.",
+            };
+          }
+        }
+        return client.getSceneState(target, { depth, limit });
+      })
   );
 
   server.tool(

--- a/src/mcp/tools/scene-tools.test.ts
+++ b/src/mcp/tools/scene-tools.test.ts
@@ -17,23 +17,197 @@ type RegisteredTool = {
   handler: (args: Record<string, unknown>) => Promise<unknown>;
 };
 
-function batchTool(): RegisteredTool {
+function sceneTool(name: string): RegisteredTool {
   const registered: RegisteredTool[] = [];
   registerSceneTools({
     tool(
-      name: string,
+      toolName: string,
       _description: string,
       _schema: Record<string, unknown>,
       handler: (args: Record<string, unknown>) => Promise<unknown>,
     ) {
-      registered.push({ name, handler });
-      return { name };
+      registered.push({ name: toolName, handler });
+      return { name: toolName };
     },
   } as never);
-  const found = registered.find((candidate) => candidate.name === "summer_batch");
-  if (!found) throw new Error("summer_batch was not registered");
+  const found = registered.find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`${name} was not registered`);
   return found;
 }
+
+function batchTool(): RegisteredTool {
+  return sceneTool("summer_batch");
+}
+
+const okReceipt = (ops: Array<Record<string, unknown>>) => ({
+  status: "ok",
+  terminalState: "applied",
+  results: ops.map((op) => ({ ok: true, op: String(op.op ?? "") })),
+});
+
+describe("summer_create_scene guarded create-only write", () => {
+  function mockCreateClient(overrides?: {
+    executeIdentityBoundOps?: ReturnType<typeof vi.fn>;
+    readProjectFile?: ReturnType<typeof vi.fn>;
+  }) {
+    const executeIdentityBoundOps =
+      overrides?.executeIdentityBoundOps ??
+      vi.fn(async (ops: Record<string, unknown>[]) => okReceipt(ops));
+    const readProjectFile =
+      overrides?.readProjectFile ??
+      vi.fn(async (path: string) => ({
+        ok: true,
+        data: {
+          content: `[gd_scene format=3]\n\n[node name="Main" type="Node3D"]\n`,
+          sha256: "a".repeat(64),
+        },
+      }));
+    const executeOps = vi.fn();
+    const health = vi.fn();
+    const getSceneState = vi.fn();
+    vi.mocked(getClient).mockResolvedValue({
+      getBoundProjectIdHash: () => "hash-a",
+      executeIdentityBoundOps,
+      executeOps,
+      readProjectFile,
+      health,
+      getSceneState,
+    } as never);
+    return { executeIdentityBoundOps, readProjectFile, executeOps, health, getSceneState };
+  }
+
+  const createArgs = {
+    path: "res://scenes/empty_level.tscn",
+    rootName: "Main",
+    rootType: "Node3D",
+  };
+
+  it("sends exactly one identity-bound create-only WriteFile with the minimal scene text", async () => {
+    const { executeIdentityBoundOps, executeOps, health, getSceneState } = mockCreateClient();
+
+    const result = (await sceneTool("summer_create_scene").handler(createArgs)) as {
+      isError?: boolean;
+      content?: Array<{ text?: string }>;
+    };
+
+    expect(result.isError).toBeUndefined();
+    expect(executeIdentityBoundOps).toHaveBeenCalledTimes(1);
+    expect(executeIdentityBoundOps.mock.calls[0]?.[0]).toEqual([
+      {
+        op: "WriteFile",
+        path: "res://scenes/empty_level.tscn",
+        content: `[gd_scene format=3]\n\n[node name="Main" type="Node3D"]\n`,
+        mustNotExist: true,
+      },
+    ]);
+    // The open scene is never touched: no OpenScene/RemoveNode/SaveScene, no
+    // template-scene resolution.
+    expect(executeOps).not.toHaveBeenCalled();
+    expect(health).not.toHaveBeenCalled();
+    expect(getSceneState).not.toHaveBeenCalled();
+
+    const body = JSON.parse(result.content?.[0]?.text ?? "{}");
+    expect(body.ok).toBe(true);
+    expect(body.created).toBe("res://scenes/empty_level.tscn");
+    expect(body.verified).toBe(true);
+  });
+
+  it("honors a custom rootType", async () => {
+    const { executeIdentityBoundOps } = mockCreateClient({
+      readProjectFile: vi.fn(async () => ({
+        ok: true,
+        data: { content: `[gd_scene format=3]\n\n[node name="Hud" type="Control"]\n` },
+      })),
+    });
+
+    await sceneTool("summer_create_scene").handler({
+      path: "res://ui/hud.tscn",
+      rootName: "Hud",
+      rootType: "Control",
+    });
+
+    const ops = executeIdentityBoundOps.mock.calls[0]?.[0] as Array<Record<string, unknown>>;
+    expect(ops[0]?.content).toBe(`[gd_scene format=3]\n\n[node name="Hud" type="Control"]\n`);
+  });
+
+  it("accepts the deprecated allow_temporary_scene_mutation param as a no-op", async () => {
+    const { executeIdentityBoundOps, executeOps } = mockCreateClient();
+
+    for (const deprecatedValue of [true, false, undefined]) {
+      executeIdentityBoundOps.mockClear();
+      const result = (await sceneTool("summer_create_scene").handler({
+        ...createArgs,
+        allow_temporary_scene_mutation: deprecatedValue,
+      })) as { isError?: boolean };
+      expect(result.isError).toBeUndefined();
+      expect(executeIdentityBoundOps).toHaveBeenCalledTimes(1);
+    }
+    expect(executeOps).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the engine's create-only refusal when the path already exists", async () => {
+    const { executeOps } = mockCreateClient({
+      executeIdentityBoundOps: vi.fn(async () => ({
+        status: "error",
+        terminalState: "failed",
+        results: [
+          {
+            ok: false,
+            op: "WriteFile",
+            error: "WriteFile new-file-only guard: target already exists. Use ReplaceText/strReplace for edits.",
+          },
+        ],
+      })),
+    });
+
+    const result = (await sceneTool("summer_create_scene").handler(createArgs)) as {
+      isError?: boolean;
+      content?: Array<{ text?: string }>;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toContain("target already exists");
+    expect(executeOps).not.toHaveBeenCalled();
+  });
+
+  it("reports a read-back verification failure honestly without failing the create", async () => {
+    mockCreateClient({
+      readProjectFile: vi.fn(async () => {
+        throw new Error("read-file endpoint unavailable");
+      }),
+    });
+
+    const result = (await sceneTool("summer_create_scene").handler(createArgs)) as {
+      isError?: boolean;
+      content?: Array<{ text?: string }>;
+    };
+
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse(result.content?.[0]?.text ?? "{}");
+    expect(body.ok).toBe(true);
+    expect(body.verified).toBe(false);
+    expect(body.verifyError).toContain("read-file endpoint unavailable");
+  });
+
+  it.each([
+    ["not res://", { ...createArgs, path: "user://a.tscn" }, "res://"],
+    ["traversal", { ...createArgs, path: "res://../a.tscn" }, "traversal-free"],
+    ["not .tscn", { ...createArgs, path: "res://a.scn" }, ".tscn"],
+    ["bad rootName", { ...createArgs, rootName: 'evil" type="Node' }, "Invalid rootName"],
+    ["bad rootType", { ...createArgs, rootType: 'Node3D"]' }, "Invalid rootType"],
+  ])("rejects invalid input (%s) before any engine write", async (_label, args, expected) => {
+    const { executeIdentityBoundOps } = mockCreateClient();
+
+    const result = (await sceneTool("summer_create_scene").handler(args)) as {
+      isError?: boolean;
+      content?: Array<{ text?: string }>;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toContain(expected);
+    expect(executeIdentityBoundOps).not.toHaveBeenCalled();
+  });
+});
 
 describe("summer_batch file mutation boundary", () => {
   it.each(["WriteFile", "ReplaceText"])(
@@ -55,4 +229,131 @@ describe("summer_batch file mutation boundary", () => {
       expect(executeOps).not.toHaveBeenCalled();
     },
   );
+});
+
+// Engine 0.5.60+ (_summer_requires_single_async_dispatch) rejects any multi-op
+// batch containing SaveScene/InstantiateScene/ReplaceNode/SimulateInput/... —
+// wholesale, before anything executes. The MCP must never put the appended
+// SaveScene in the same request as the mutations it saves.
+describe("single-op dispatch contract (engine 0.5.60+)", () => {
+  function mockClient() {
+    const calls: Array<Record<string, unknown>[]> = [];
+    const executeIdentityBoundOps = vi.fn(async (ops: Record<string, unknown>[]) => {
+      calls.push(ops);
+      return okReceipt(ops);
+    });
+    vi.mocked(getClient).mockResolvedValue({
+      getBoundProjectIdHash: () => "hash-a",
+      executeIdentityBoundOps,
+      executeOps: vi.fn(async (ops: Record<string, unknown>[]) => okReceipt(ops)),
+    } as never);
+    return { calls, executeIdentityBoundOps };
+  }
+
+  it("summer_add_node sends the mutation and the appended SaveScene as two sequential requests", async () => {
+    const { calls } = mockClient();
+    const result = (await sceneTool("summer_add_node").handler({
+      scenePath: "res://main.tscn",
+      parent: "./World",
+      type: "MeshInstance3D",
+      name: "Floor",
+    })) as { isError?: boolean; content?: Array<{ text?: string }> };
+
+    expect(result.isError).toBeUndefined();
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toEqual([{ op: "AddNode", parent: "./World", type: "MeshInstance3D", name: "Floor" }]);
+    expect(calls[1]).toEqual([{ op: "SaveScene" }]);
+    // No request may mix SaveScene with other ops.
+    for (const ops of calls) {
+      if (ops.some((op) => op.op === "SaveScene")) expect(ops).toHaveLength(1);
+    }
+  });
+
+  it("summer_batch keeps batchable mutations grouped and splits only around single-only ops", async () => {
+    const { calls } = mockClient();
+    await batchTool().handler({
+      scenePath: "res://main.tscn",
+      ops: [
+        { op: "AddNode", parent: "/", type: "Node3D", name: "A" },
+        { op: "SetProp", path: "A", key: "visible", value: true },
+        { op: "InstantiateScene", parent: "/", scene: "res://b.tscn" },
+        { op: "SetProp", path: "B", key: "visible", value: false },
+      ],
+    });
+
+    expect(calls).toEqual([
+      [
+        { op: "AddNode", parent: "/", type: "Node3D", name: "A" },
+        { op: "SetProp", path: "A", key: "visible", value: true },
+      ],
+      [{ op: "InstantiateScene", parent: "/", scene: "res://b.tscn" }],
+      [{ op: "SetProp", path: "B", key: "visible", value: false }],
+      [{ op: "SaveScene" }],
+    ]);
+  });
+
+  it("merges all receipts on success so every op result stays visible", async () => {
+    mockClient();
+    const result = (await sceneTool("summer_set_prop").handler({
+      scenePath: "res://main.tscn",
+      path: "./Floor",
+      key: "visible",
+      value: true,
+    })) as { content?: Array<{ text?: string }> };
+
+    const body = JSON.parse(result.content?.[0]?.text ?? "{}");
+    expect(body.requests).toBe(2);
+    expect(body.results.map((entry: { op: string }) => entry.op)).toEqual(["SetProp", "SaveScene"]);
+  });
+
+  it("reports an applied mutation followed by a failed save honestly", async () => {
+    const executeIdentityBoundOps = vi.fn(async (ops: Record<string, unknown>[]) => {
+      if (ops.some((op) => op.op === "SaveScene")) {
+        return {
+          status: "error",
+          terminalState: "failed",
+          error: "disk full",
+          results: [{ ok: false, op: "SaveScene", failure_reason: "io_error" }],
+        };
+      }
+      return okReceipt(ops);
+    });
+    vi.mocked(getClient).mockResolvedValue({
+      getBoundProjectIdHash: () => "hash-a",
+      executeIdentityBoundOps,
+      executeOps: vi.fn(),
+    } as never);
+
+    const result = (await sceneTool("summer_add_node").handler({
+      scenePath: "res://main.tscn",
+      parent: "./World",
+      type: "MeshInstance3D",
+      name: "Floor",
+    })) as { isError?: boolean; content?: Array<{ text?: string }> };
+
+    expect(result.isError).toBe(true);
+    const text = result.content?.[0]?.text ?? "";
+    expect(text).toContain("disk full");
+    expect(text).toContain("already applied");
+    expect(text).toContain("NOT saved");
+    expect(text).toContain("io_error");
+  });
+
+  it("sends a lone SimulateInput through summer_batch as a single op with no SaveScene appended", async () => {
+    const executeOps = vi.fn(async (ops: Record<string, unknown>[]) => okReceipt(ops));
+    vi.mocked(getClient).mockResolvedValue({
+      getBoundProjectIdHash: () => "hash-a",
+      executeIdentityBoundOps: vi.fn(),
+      executeOps,
+    } as never);
+
+    await batchTool().handler({
+      ops: [{ op: "SimulateInput", type: "action", action: "jump", pressed: true }],
+    });
+
+    expect(executeOps).toHaveBeenCalledTimes(1);
+    expect(executeOps.mock.calls[0]?.[0]).toEqual([
+      { op: "SimulateInput", type: "action", action: "jump", pressed: true },
+    ]);
+  });
 });

--- a/src/mcp/tools/scene-tools.ts
+++ b/src/mcp/tools/scene-tools.ts
@@ -1,9 +1,24 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { withEngine } from "./with-engine.js";
-import { readFile } from "fs/promises";
-import { join } from "path";
+import { withEngine, extractOpError } from "./with-engine.js";
 import type { EngineApiClient } from "../../lib/api-client.js";
+
+// Engine ops that MUST be dispatched as their own single-op request. Mirrors
+// _summer_requires_single_async_dispatch (local_api_server.cpp, engine 0.5.60+):
+// the engine rejects any multi-op batch containing one of these WHOLESALE —
+// nothing in the batch executes, and the batch fails with per-op
+// failure_reason "unsupported_transport"/"skipped". Git ops are covered by the
+// prefix check below.
+const SINGLE_ONLY_OPS = new Set([
+  "SaveScene", "InstantiateScene", "ReplaceNode",
+  "SimulateInput", "ViewportSnapshot", "GameSnapshot",
+  "RunCommand", "RunVerification", "RunEditorScript",
+  "ImportFromUrl", "ImportFromUrlBatch", "ExtractZipFromUrl",
+]);
+
+function isSingleOnlyOp(kind: string): boolean {
+  return SINGLE_ONLY_OPS.has(kind) || kind.startsWith("Git");
+}
 
 function sceneMutationOps(ops: Record<string, unknown>[]): Record<string, unknown>[] {
   const saveIndexes = ops
@@ -21,27 +36,85 @@ function sceneMutationOps(ops: Record<string, unknown>[]): Record<string, unknow
   return [...ops, { op: "SaveScene" }];
 }
 
+/** Split an op list into sequential engine requests: consecutive batchable ops
+ *  stay grouped, each single-only op becomes its own request. Order preserved. */
+function chunkOpsForDispatch(ops: Record<string, unknown>[]): Record<string, unknown>[][] {
+  const chunks: Record<string, unknown>[][] = [];
+  let current: Record<string, unknown>[] = [];
+  for (const op of ops) {
+    if (isSingleOnlyOp(String(op.op ?? ""))) {
+      if (current.length > 0) {
+        chunks.push(current);
+        current = [];
+      }
+      chunks.push([op]);
+    } else {
+      current.push(op);
+    }
+  }
+  if (current.length > 0) chunks.push(current);
+  return chunks;
+}
+
+/** Execute an op list as sequential engine requests honoring the single-op
+ *  dispatch contract. Receipts from every request are preserved and merged, so
+ *  an op that applied followed by one that failed is reported honestly instead
+ *  of masked. */
+async function executeOpsChunked(
+  send: (chunk: Record<string, unknown>[]) => Promise<unknown>,
+  ops: Record<string, unknown>[],
+): Promise<unknown> {
+  const chunks = chunkOpsForDispatch(ops);
+  if (chunks.length === 1) return send(chunks[0]!);
+
+  const receipts: unknown[] = [];
+  const combinedResults: Array<Record<string, unknown>> = [];
+  for (let i = 0; i < chunks.length; i++) {
+    const receipt = await send(chunks[i]!);
+    receipts.push(receipt);
+    const envelope = (receipt ?? {}) as Record<string, unknown>;
+    if (Array.isArray(envelope.results)) {
+      combinedResults.push(...(envelope.results as Array<Record<string, unknown>>));
+    }
+    if (extractOpError(receipt)) {
+      const failedKind = String(chunks[i]![0]?.op ?? "batch");
+      const appliedOps = chunks.slice(0, i).flat().map((op) => String(op.op ?? ""));
+      const notSent = chunks.slice(i + 1).flat().map((op) => String(op.op ?? ""));
+      const baseError =
+        (typeof envelope.error === "string" && envelope.error) || `Engine request failed (${failedKind}).`;
+      const honestError =
+        appliedOps.length > 0
+          ? `${baseError} NOTE: ${appliedOps.length} earlier op(s) already applied (${appliedOps.join(", ")})` +
+            (failedKind === "SaveScene"
+              ? " — the scene is modified in the editor but NOT saved to disk. Fix the problem, then call summer_save_scene."
+              : ".") +
+            (notSent.length > 0 ? ` Not sent: ${notSent.join(", ")}.` : "")
+          : baseError;
+      return {
+        ...envelope,
+        error: honestError,
+        results: combinedResults,
+        receipts,
+      };
+    }
+  }
+  const last = (receipts[receipts.length - 1] ?? {}) as Record<string, unknown>;
+  return { ...last, results: combinedResults, requests: chunks.length, receipts };
+}
+
+/** Scene mutation entry point: appends the transaction-boundary SaveScene, then
+ *  dispatches with the single-op contract (mutations batch together, SaveScene
+ *  and other single-only ops travel alone). */
 function executeSceneMutation(
   client: EngineApiClient,
   scenePath: string,
   ops: Record<string, unknown>[],
   options?: Record<string, unknown>,
 ): Promise<unknown> {
-  return client.executeIdentityBoundOps(sceneMutationOps(ops), {
-    ...(options ?? {}),
-    scenePath,
-  });
-}
-
-async function readMainSceneFromProject(projectPath?: string): Promise<string | null> {
-  if (!projectPath) return null;
-  try {
-    const text = await readFile(join(projectPath, "project.godot"), "utf-8");
-    const match = text.match(/run\/main_scene="([^"]+)"/);
-    return match?.[1] ?? null;
-  } catch {
-    return null;
-  }
+  return executeOpsChunked(
+    (chunk) => client.executeIdentityBoundOps(chunk, { ...(options ?? {}), scenePath }),
+    sceneMutationOps(ops),
+  );
 }
 
 function requireSuccessfulOps(result: unknown, context: string): Record<string, unknown> {
@@ -60,89 +133,115 @@ function requireSuccessfulOps(result: unknown, context: string): Record<string, 
   return receipt;
 }
 
+/** Compose the minimal valid .tscn text scene: header + one root node.
+ *  `uid` and `load_steps` are optional in the engine parser
+ *  (resource_format_text.cpp treats a missing uid as INVALID_ID); the editor
+ *  assigns a uid on first save. */
+function minimalSceneText(rootName: string, rootType: string): string {
+  return `[gd_scene format=3]\n\n[node name="${rootName}" type="${rootType}"]\n`;
+}
+
+// Node names reject . : @ / " %; the type must be a plain class name.
+// Both are interpolated into quoted .tscn fields, so validate before composing.
+const VALID_ROOT_NAME = /^[A-Za-z_][A-Za-z0-9_\- ]*$/;
+const VALID_ROOT_TYPE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 export function registerSceneTools(server: McpServer): void {
   server.tool(
     "summer_create_scene",
-    `Create a new empty scene file safely.
+    `Create a new empty scene file. Writes a minimal .tscn through the identity-bound engine with a create-only guard: it fails if the path already exists, and it never touches the currently open scene.
 
-IMPORTANT:
-- This tool uses a temporary mutation strategy: it opens a template scene, removes children, saves to a new path, then restores the previous scene.
-- To prevent accidental destructive actions, you MUST explicitly set allow_temporary_scene_mutation=true.
-- If you don't want this strategy, stop and ask the user for manual scene creation in the editor.
+The new scene is on disk but NOT opened. Call summer_open_scene to start editing it, then summer_add_node to build it out.
 
 Recommended workflow:
 1) Call summer_get_project_context
-2) Call summer_open_main_scene (optional)
-3) Call summer_create_scene with a new path`,
+2) Call summer_create_scene with a new res:// path
+3) Call summer_open_scene with that path`,
     {
       path: z.string().describe("New scene path, e.g. 'res://scenes/empty_level.tscn'"),
       rootName: z.string().default("Main").describe("Root node name for the new scene"),
+      rootType: z
+        .string()
+        .default("Node3D")
+        .describe(
+          "Root node type. Default 'Node3D' (3D scenes); common alternatives: 'Node2D' (2D scenes), 'Control' (UI scenes), 'Node' (logic-only)."
+        ),
       allow_temporary_scene_mutation: z
         .boolean()
-        .default(false)
-        .describe("Safety gate. Must be true to proceed."),
+        .optional()
+        .describe(
+          "DEPRECATED, ignored. Scene creation no longer mutates any open scene; kept only so older callers don't break."
+        ),
     },
-    async ({ path, rootName, allow_temporary_scene_mutation }) =>
+    async ({ path, rootName, rootType }) =>
       withEngine(async (client) => {
-        if (!allow_temporary_scene_mutation) {
+        const safePath = path.trim().replace(/\\/g, "/");
+        if (!safePath.startsWith("res://") || safePath.includes("..")) {
+          throw new Error("Scene path must be a traversal-free res:// project path.");
+        }
+        if (!safePath.endsWith(".tscn")) {
+          throw new Error("New scenes must use the text format: the path must end in .tscn.");
+        }
+        if (!VALID_ROOT_NAME.test(rootName)) {
           throw new Error(
-            "Refusing to create scene without explicit approval. Re-run with allow_temporary_scene_mutation=true."
+            `Invalid rootName "${rootName}": use letters, digits, underscores, hyphens, or spaces, starting with a letter or underscore.`
+          );
+        }
+        if (!VALID_ROOT_TYPE.test(rootType)) {
+          throw new Error(
+            `Invalid rootType "${rootType}": must be a plain class name like 'Node3D', 'Node2D', or 'Control'.`
           );
         }
 
-        const health = (await client.health()) as Record<string, unknown>;
-        const currentScene =
-          typeof health.scene === "string" && health.scene.length > 0 ? health.scene : null;
-        const projectPath =
-          typeof health.project_path === "string" ? health.project_path : undefined;
-        const mainScene = await readMainSceneFromProject(projectPath);
-        const templateScene = currentScene || mainScene;
-
-        if (!templateScene) {
-          throw new Error(
-            "No scene open and could not resolve main scene. Call summer_get_project_context first, then open a known scene."
-          );
-        }
-
-        await client.executeOps([{ op: "OpenScene", path: templateScene }]);
-        const tree = (await client.getSceneState(templateScene)) as {
-          data?: { children?: Array<{ path?: string }> };
-          children?: Array<{ path?: string }>;
-        };
-        const children =
-          tree.data?.children ?? tree.children ?? [];
-
-        const removeOps = children
-          .map((c) => c.path)
-          .filter((p): p is string => typeof p === "string" && p.length > 0)
-          .map((p) => ({ op: "RemoveNode", path: `./${p}` }));
-
-        const createOps = [
-          ...removeOps,
-          { op: "SetProp", path: ".", key: "name", value: rootName },
-          { op: "SaveScene", path },
-        ];
-        const createReceipt = requireSuccessfulOps(
-          await executeSceneMutation(client, templateScene, createOps, {
-            groupUndo: true,
-          }),
-          `Creating ${path}`,
+        // Same engine-routed guarded write path summer_write_file uses:
+        // identity-bound, and mustNotExist makes the engine refuse (create-only)
+        // if the path already exists. The open scene is never touched.
+        const receipt = requireSuccessfulOps(
+          await client.executeIdentityBoundOps([
+            {
+              op: "WriteFile",
+              path: safePath,
+              content: minimalSceneText(rootName, rootType),
+              mustNotExist: true,
+            },
+          ]),
+          `Creating ${safePath}`,
         );
 
-        if (currentScene && currentScene !== path) {
-          requireSuccessfulOps(
-            await client.executeOps([{ op: "OpenScene", path: currentScene }]),
-            `Restoring ${currentScene}`,
-          );
+        // Post-write verification: read the file back through the engine. The
+        // write receipt already passed; a read-back failure is reported honestly
+        // instead of failing the create or being masked.
+        let verified = false;
+        let verifyError: string | undefined;
+        try {
+          const read = (await client.readProjectFile(safePath, 4096)) as {
+            ok?: boolean;
+            error?: unknown;
+            data?: { content?: unknown };
+          };
+          const content = typeof read?.data?.content === "string" ? read.data.content : null;
+          if (read?.ok === false) {
+            verifyError = String(read.error ?? "engine could not read the file back");
+          } else if (content === null) {
+            verifyError = "engine returned no text content on read-back";
+          } else if (!content.includes(`[node name="${rootName}"`)) {
+            verifyError = "read-back content does not contain the expected root node";
+          } else {
+            verified = true;
+          }
+        } catch (err) {
+          verifyError = err instanceof Error ? err.message : String(err);
         }
 
         return {
           ok: true,
-          created: path,
+          created: safePath,
           rootName,
-          templateScene,
-          restoredScene: currentScene,
-          receipt: createReceipt,
+          rootType,
+          verified,
+          ...(verifyError ? { verifyError } : {}),
+          receipt,
+          hint: "The new scene is on disk but not open. Call summer_open_scene to start editing it.",
         };
       })
   );
@@ -395,13 +494,18 @@ Each op in the array uses the same format as the individual tools:
 - {"op": "SetResourceProperty", "nodePath": "Floor", "resourceProperty": "mesh", "subProperty": "size", "value": "Vector2(20, 20)"}
 
 RAW RUNTIME OPS (interactive verification — structured failure_reason passes through verbatim):
-- RunVerification — spawn a hidden, disposable game instance that runs a GDScript probe and dies (never touches the editor): {"op": "RunVerification", "probe_source": "extends SummerProbeBase\\nfunc _ready(): await super._ready(); report('ok', true); finish()", "max_seconds": 20}. Returns {ok, results, frames, out_dir}. Probe API: report()/save_frame()/press()/key()/finish(). This is the ONLY way to drive input from MCP, and unlike the editor it renders real pixels, so save_frame() produces a real image.
-- SimulateInput is NOT reachable from MCP or the CLI. It requires the in-editor chat bridge's async reply channel; every queued caller gets {"ok": false, "failure_reason": "unsupported_transport"} on every engine build. Do not send it and do not treat that reply as a version problem — use RunVerification's press()/key() instead.
+- RunVerification — spawn a hidden, disposable game instance that runs a GDScript probe and dies (never touches the editor): {"op": "RunVerification", "probe_source": "...", "max_seconds": 20}. Returns {ok, results, frames, out_dir}. Probe API: report(name, value) / save_frame(name) / press(action) / key(keycode) / finish(). save_frame REQUIRES a name argument — save_frame() with no args is a script error. Mount scenes deferred: get_tree().root.add_child.call_deferred(instance); await get_tree().process_frame; await settle() — a direct add_child in _ready can hit the parent-busy guard and capture a black frame.
+- SimulateInput — inject an action/key/mouse/axis into the RUNNING game (summer_play first): {"op": "SimulateInput", "type": "action", "action": "jump", "pressed": true}. It MUST be sent alone (single-op batch). failure_reason "not_running" = start the game first; "unsupported" = the running game build predates the handler — fall back to RunVerification or ask the user.
 
 Do not mix OpenScene with scene mutations in one batch. OpenScene is a UI action;
 send it separately. scenePath selects every mutation target. The tool appends one
 final SaveScene when the batch mutates a scene; if supplied explicitly, SaveScene
-must appear exactly once and be the final operation.`,
+must appear exactly once and be the final operation. The engine requires
+SaveScene, InstantiateScene, ReplaceNode, SimulateInput, and the Run*/Import*
+ops to travel as their own request, so this tool automatically splits your op
+list into sequential requests around them — each split chunk is its own undo
+step, and if a later chunk fails the receipt reports exactly which earlier ops
+already applied.`,
     {
       scenePath: z.string().optional().describe(
         "Required when ops contains scene mutations; exact res:// target scene path",
@@ -432,7 +536,10 @@ must appear exactly once and be the final operation.`,
         const options = { groupUndo: true, ...(scenePath ? { scenePath } : {}) };
         return needsScenePath
           ? executeSceneMutation(client, scenePath!, ops as Record<string, unknown>[], options)
-          : client.executeOps(ops as Record<string, unknown>[], options);
+          : executeOpsChunked(
+              (chunk) => client.executeOps(chunk, options),
+              ops as Record<string, unknown>[],
+            );
       })
   );
 }

--- a/src/mcp/tools/visual-tools.ts
+++ b/src/mcp/tools/visual-tools.ts
@@ -23,7 +23,7 @@ target:
     It does NOT use the scene's environment/sky, and it injects a synthetic camera and light when the scene has none. The scene's WorldEnvironment — sky, fog, tonemap, glow, SSAO, ambient — is replaced by a flat preview environment. So this target CANNOT verify lighting, mood, or any material property that depends on the environment: change them and the frame comes back identical. For those, boot the game or run a RunVerification probe, whose instance renders the real environment.
   "game" — a frame from the RUNNING game (real runtime state). Start the game first (summer_play). Not available over a plain local connection — needs the Summer desktop app bridge.
 
-Static frame only — one moment, not motion. For a SEQUENCE of frames over time, or for anything lighting-dependent when the desktop bridge is unavailable, use a RunVerification probe's save_frame() — its instance has a real renderer.`,
+Static frame only — one moment, not motion. For a SEQUENCE of frames over time, or for anything lighting-dependent when the desktop bridge is unavailable, use a RunVerification probe's save_frame(name) — its instance has a real renderer.`,
     {
       target: z
         .enum(["viewport", "scene", "game"])
@@ -39,9 +39,14 @@ Static frame only — one moment, not motion. For a SEQUENCE of frames over time
           'target:"scene" only. Full scene path, e.g. "res://main.tscn". Omit to render the currently-open scene.'
         ),
       framing: z
-        .enum(["auto", "top", "front", "iso"])
+        .enum(["auto", "iso", "top", "front", "back", "left", "right"])
         .optional()
-        .describe('target:"scene" only. Camera framing preset. Default: auto.'),
+        .describe(
+          'target:"scene" only, 3D scenes. Camera direction preset: "iso" = 3/4 diagonal view, ' +
+            '"top" = straight down, "front" = camera at +Z, "back" = camera at -Z, ' +
+            '"left" = camera at -X, "right" = camera at +X. "auto" (default) is an alias of "iso". ' +
+            "The result reports the resolved framing."
+        ),
       size: z
         .array(z.number().int().positive())
         .length(2)
@@ -50,7 +55,12 @@ Static frame only — one moment, not motion. For a SEQUENCE of frames over time
       nodePath: z
         .string()
         .optional()
-        .describe('target:"scene" only. Scene-tree node path to frame on.'),
+        .describe(
+          'target:"scene" only. Node path relative to the scene root (e.g. "Player/Mesh") to frame ' +
+            "INSTEAD of the whole scene — the camera fits that node's combined bounds (3D visual AABBs " +
+            "or 2D rects, children included). A bare unique name is also found recursively. " +
+            'Fails with failure_reason "node_not_found" when the path does not resolve (no silent whole-scene fallback).'
+        ),
     },
     async ({ target, scenePath, framing, size, nodePath }) =>
       withEngine(
@@ -136,15 +146,30 @@ Static frame only — one moment, not motion. For a SEQUENCE of frames over time
                   "WARNING: this scene has no light — lit materials may appear black when played."
                 );
               }
+              // The engine ALWAYS synthesizes the preview camera (preview_ops.cpp
+              // sets used_synthetic_camera unconditionally) — the flag says nothing
+              // about the scene's own cameras. sceneHasCamera above is the
+              // authoritative "does this scene have a camera" answer.
               if (snap.usedSyntheticCamera) {
                 warnings.push(
-                  "NOTE: this preview used a synthetic camera the engine added just for the render — the scene itself has no camera, so it will NOT frame like this when played."
+                  "NOTE: this preview is framed by a synthetic render camera, NOT the scene's own camera — the played game will not frame like this image."
                 );
               }
             }
 
+            // Scene-preview capture details: resolved framing ("auto" -> "iso"),
+            // which node was framed (confirms nodePath resolved), and how many
+            // blank-readback retries the engine needed (0 = omitted).
+            const details: string[] = [];
+            if (target === "scene") {
+              if (snap.framing) details.push(`framing: ${snap.framing}`);
+              if (snap.framedNode) details.push(`framed node: ${snap.framedNode}`);
+              if (snap.renderRetries) details.push(`render retries: ${snap.renderRetries}`);
+            }
+            const detailNote = details.length ? `; ${details.join(", ")}` : "";
+
             const caption =
-              `${label} (${dims}). Saved to ${snap.localPath ?? "n/a"}. Review the image above and describe what you actually see.` +
+              `${label} (${dims}${detailNote}). Saved to ${snap.localPath ?? "n/a"}. Review the image above and describe what you actually see.` +
               (warnings.length ? `\n\n${warnings.join("\n")}` : "");
 
             return [

--- a/src/mcp/tools/with-engine.test.ts
+++ b/src/mcp/tools/with-engine.test.ts
@@ -134,3 +134,85 @@ describe("extractOpError — non-records", () => {
     expect(extractOpError(42)).toBeNull();
   });
 });
+
+describe("extractOpError — classified failures preserve failure_reason (E-hotfix 2.8.1)", () => {
+  it("surfaces a nested failure_reason even when the envelope carries its own error string", () => {
+    const text = extractOpError({
+      status: "error",
+      terminalState: "failed",
+      errorClass: "fatal",
+      error: "failed",
+      results: [
+        {
+          ok: false,
+          op: "SimulateInput",
+          error: "SimulateInput must be sent as a single op so it cannot block the editor thread.",
+          failure_reason: "unsupported_transport",
+        },
+      ],
+    });
+    const parsed = JSON.parse(text ?? "");
+    expect(parsed.failure_reason).toBe("unsupported_transport");
+    expect(parsed.error).toBe("failed");
+    expect(parsed.op_error).toContain("single op");
+    expect(parsed.op).toBe("SimulateInput");
+    expect(parsed.terminalState).toBe("failed");
+  });
+
+  it("prefers the failed op's precise error over the generic terminal-state sentence (the 2.8.0 masking bug)", () => {
+    const text = extractOpError({
+      terminalState: "failed",
+      errorClass: "fatal",
+      results: [
+        {
+          ok: false,
+          op: "SaveScene",
+          error: "SaveScene must be sent as a single op so it cannot block the editor thread.",
+          failure_reason: "unsupported_transport",
+        },
+      ],
+    });
+    const parsed = JSON.parse(text ?? "");
+    expect(parsed.error).toContain("must be sent as a single op");
+    expect(parsed.failure_reason).toBe("unsupported_transport");
+    expect(text).not.toContain("Engine operation failed (terminalState: failed)");
+  });
+
+  it("keeps the informative envelope error (plain text) when the failed results entry has no classifier", () => {
+    expect(
+      extractOpError({
+        status: "error",
+        error: "scene locked by running game — stop first",
+        results: [{ ok: false, op: "SetProp" }],
+      })
+    ).toBe("scene locked by running game — stop first");
+  });
+
+  it("surfaces a nested failure_reason on an ok:false envelope", () => {
+    const text = extractOpError({
+      ok: false,
+      error: "op rejected",
+      results: [{ ok: false, op: "SimulateInput", failure_reason: "unsupported_transport" }],
+    });
+    const parsed = JSON.parse(text ?? "");
+    expect(parsed.failure_reason).toBe("unsupported_transport");
+    expect(parsed.error).toBe("op rejected");
+  });
+
+  it("surfaces a top-level failure_reason on a bare terminal envelope (no error, no results)", () => {
+    const text = extractOpError({ terminalState: "timed_out", failure_reason: "queue_full" });
+    const parsed = JSON.parse(text ?? "");
+    expect(parsed.failure_reason).toBe("queue_full");
+    expect(parsed.terminalState).toBe("timed_out");
+    expect(parsed.error).toMatch(/timed out/i);
+  });
+
+  it("accepts the camelCase failureReason spelling on nested entries", () => {
+    const text = extractOpError({
+      terminalState: "failed",
+      results: [{ ok: false, op: "AddNode", failureReason: "skipped" }],
+    });
+    const parsed = JSON.parse(text ?? "");
+    expect(parsed.failure_reason).toBe("skipped");
+  });
+});

--- a/src/mcp/tools/with-engine.ts
+++ b/src/mcp/tools/with-engine.ts
@@ -51,8 +51,25 @@ type OpResult = {
   errorClass?: string;
   failureReason?: string;
   failure_reason?: string;
-  results?: Array<{ ok?: boolean; op?: string; error?: string }>;
+  results?: Array<{
+    ok?: boolean;
+    op?: string;
+    error?: string;
+    failureReason?: string;
+    failure_reason?: string;
+  }>;
 };
+
+function getFailureReason(value: {
+  failureReason?: string;
+  failure_reason?: string;
+}): string | undefined {
+  return typeof value.failureReason === "string"
+    ? value.failureReason
+    : typeof value.failure_reason === "string"
+      ? value.failure_reason
+      : undefined;
+}
 
 // 0.5.34 Block E contract (publicsummerengine src/lib/tools/contract.ts §0.1).
 // The async lifecycle (async-op-lifecycle.ts pollOpToTerminal) merges
@@ -88,15 +105,11 @@ const TERMINAL_STATE_MESSAGES: Record<string, string> = {
 function readClassifiers(result: unknown): Pick<WithEngineMeta, "terminalState" | "errorClass" | "failureReason"> {
   if (!result || typeof result !== "object") return {};
   const op = result as OpResult;
+  const failed = op.results?.find((entry) => entry.ok === false);
   return {
     terminalState: typeof op.terminalState === "string" ? op.terminalState : undefined,
     errorClass: typeof op.errorClass === "string" ? op.errorClass : undefined,
-    failureReason:
-      typeof op.failureReason === "string"
-        ? op.failureReason
-        : typeof op.failure_reason === "string"
-          ? op.failure_reason
-          : undefined,
+    failureReason: getFailureReason(op) ?? (failed ? getFailureReason(failed) : undefined),
   };
 }
 
@@ -116,24 +129,61 @@ function readClassifiers(result: unknown): Pick<WithEngineMeta, "terminalState" 
 export function extractOpError(result: unknown): string | null {
   if (!result || typeof result !== "object") return null;
   const op = result as OpResult;
+  const firstFailed = op.results?.find((r) => r.ok === false);
+  // The engine stamps failure classifiers on the envelope OR per-op inside
+  // results[] (the batch gate does the latter) — read both.
+  const failureReason = getFailureReason(op) ?? (firstFailed ? getFailureReason(firstFailed) : undefined);
+
+  // Classified failures are rendered as JSON so callers can reliably read
+  // failure_reason instead of scraping a sentence. A plain-text "Hint:" line may
+  // follow the JSON in the final tool text. Unclassified failures stay plain.
+  const classify = (message: string): string => {
+    if (!failureReason) return message;
+    return JSON.stringify(
+      {
+        error: message,
+        failure_reason: failureReason,
+        ...(typeof firstFailed?.error === "string" && firstFailed.error.length > 0 && firstFailed.error !== message
+          ? { op_error: firstFailed.error }
+          : {}),
+        ...(typeof firstFailed?.op === "string" ? { op: firstFailed.op } : {}),
+        ...(typeof op.terminalState === "string" ? { terminalState: op.terminalState } : {}),
+        ...(typeof op.errorClass === "string" ? { errorClass: op.errorClass } : {}),
+      },
+      null,
+      2
+    );
+  };
 
   // Failure terminalState takes precedence — it is set by the async lifecycle
   // exactly when the op did not land (timeout, backpressure, lease/identity
-  // rejection, cancellation), often with NO results[] to inspect.
+  // rejection, cancellation), sometimes with NO results[] to inspect. Prefer the
+  // precise engine rejection (envelope error, then the failed op's error) over
+  // the generic terminal-state sentence.
   const ts = op.terminalState;
   if (typeof ts === "string" && ts.length > 0 && !SUCCESS_TERMINAL_STATES.has(ts)) {
-    if (typeof op.error === "string" && op.error.length > 0) return op.error;
-    return TERMINAL_STATE_MESSAGES[ts] ?? `Engine operation failed (terminalState: ${ts}).`;
+    const message =
+      (typeof op.error === "string" && op.error.length > 0 && op.error) ||
+      (typeof firstFailed?.error === "string" && firstFailed.error.length > 0 && firstFailed.error) ||
+      TERMINAL_STATE_MESSAGES[ts] ||
+      `Engine operation failed (terminalState: ${ts}).`;
+    return classify(message);
   }
 
-  // An explicit ok:false / status:"error" is a failure even when the engine
-  // omitted an error string — surface it rather than mask it (matches the web
-  // contract `isFailureSignal`).
-  if (op.ok === false) return op.error || "Engine operation failed (ok: false).";
-  if (op.status === "error") return op.error || "Engine operation failed (status: error).";
-  const firstFailed = op.results?.find((r) => r.ok === false);
-  if (firstFailed) {
-    return firstFailed.error || `Engine op failed${firstFailed.op ? ` (${firstFailed.op})` : ""}.`;
+  // An explicit ok:false / status:"error" / failed op inside results[] is a
+  // failure even when the engine omitted an error string — surface it rather
+  // than mask it (matches the web contract `isFailureSignal`). The envelope
+  // error is kept when present; the failed op's own error backs it up.
+  if (op.ok === false || op.status === "error" || firstFailed) {
+    const message =
+      (typeof op.error === "string" && op.error.length > 0 && op.error) ||
+      (typeof firstFailed?.error === "string" && firstFailed.error.length > 0 && firstFailed.error) ||
+      (firstFailed
+        ? `Engine op failed${firstFailed.op ? ` (${firstFailed.op})` : ""}.`
+        : op.ok === false
+          ? "Engine operation failed (ok: false)."
+          : "Engine operation failed (status: error).");
+    return classify(message);
   }
   return null;
 }


### PR DESCRIPTION
Reconciles the public repository with the 2.8.1 hotfix from the engine monorepo.

Fixes the P0 regression where engine 0.5.60+ rejected every MCP scene-mutation batch (SaveScene single-only contract), plus precise failure_reason surfacing, guarded create-only summer_create_scene, doc corrections (SimulateInput single-op, save_frame name arg), scene-tree/context payload controls, prioritized diagnostics, the compat-smoke release gate, and the stale README banner removal.

Verified in this checkout: npm ci, 432/432 tests, build, publish dry-run at 2.8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)