### PR TITLE
Add customer hosted Build publication CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to summer-engine will be documented here. Following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+
+- `summer build publish [project] --version <value>` is the supported hosted
+  server-Build client: deterministic source ZIP, platform-owned
+  `BuildPublication` draft, bounded direct upload, source sealing, explicit
+  draft publication, and worker-state observation through immutable Build
+  readiness. It never creates or deploys a Release.
+- `summer login --platform` uses a separately stored Supabase developer access
+  token obtained with OAuth authorization code + PKCE. The existing core and
+  Summercraft creator credentials remain separate.
+
+### Changed
+
+- Hosted Build declarations keep only stable creator intent in
+  `summer.build.json`; the platform supplies active Engine and SDK policy when
+  those optional compatibility assertions are omitted.
+
 ## [2.8.1] — 2026-08-18 — "Scene mutations work again on engine 0.5.60+"
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 Build real 2D and 3D Summer games with Summer Engine, the Summer SDK, and
 GDScript. The agent layer can help author code and scenes, but creators remain
 in control of changes and release decisions. Local export support depends on
-the templates present in the installed engine. The package does not silently
-build, host, or submit games to stores; its explicit, confirmed creator command
-can publish an already-exported Summer `.pck` to Summercraft for review.
+the templates present in the installed engine. The package never silently
+publishes or deploys. Its explicit commands can publish an already-exported
+Summer `.pck` to Summercraft for review or submit a declared server source
+archive to a configured Summer platform BuildPublication pipeline.
 
 **Summer** is the MIT open-source agent layer that connects your AI coding agent to Summer Engine. It is the **Summer CLI**, the **Summer MCP** server, and the **Summer agent** skills, hooks, and plugin manifests, all in one package. First-class setup works in Claude Code, Cursor, Codex, Devin Desktop (formerly Windsurf), Cline, Roo Code, Gemini CLI, GitHub Copilot CLI, GitHub Copilot in VS Code, and OpenCode. Factory Droid uses the plugin marketplace path.
 
@@ -225,6 +226,7 @@ We tell you before we touch your disk.
 | Summer Engine app | ~1 GB (engine + bundled Git/runtime tools) | `npx -y summer-engine@latest install` | Summer's signed releases |
 | Auth token | ~1 KB | `npx -y summer-engine@latest login` | Browser to `~/.summer/auth-token` |
 | Creator token | ~50 bytes | only when you run `summer login --creator` and mint one | One-time browser value to `~/.summer/creator-token`; never replaces the auth token |
+| Developer platform session | ~2 KB | only when you run `summer login --platform` | Supabase OAuth 2.1 authorization code + PKCE; access and refresh tokens stay in mode-`0600` `~/.summer/platform-session.json` |
 | Skill files | < 50 KB | bundled in the npm package | no extra network call |
 | Generated assets (3D / image / audio / video) | varies | only on explicit `summer_generate_*` calls when that provider route is enabled for the account | Summer Engine Studio |
 | URL imports | varies | only on explicit `summer_import_from_url` calls | the URL you provide |
@@ -506,13 +508,58 @@ npx -y summer-engine@latest doctor
 
 ## CLI reference
 
+### Developer Preview: publish a hosted server Build
+
+Hosted Build publication follows one supported creator path. The CLI packages
+the current source deterministically, creates a platform `BuildPublication`
+draft, uploads through that draft's bounded one-time grant, completes source
+intake, explicitly publishes the sealed draft, and waits for trusted platform
+workers to return an immutable ready Build. It does not run the trusted
+toolchain locally, push an image, mint
+provenance, or create/deploy a Release.
+
+Commit one stable `summer.build.json` at the archive root:
+
+```json
+{
+  "schema": "summer.build.v1",
+  "gameId": "game_your_game",
+  "project": { "directory": "." },
+  "server": { "exportPreset": "Summer Dedicated Server" },
+  "runtime": {
+    "protocolVersion": "1",
+    "scenes": ["res://AuthorityMain.tscn"],
+    "queues": []
+  }
+}
+```
+
+Configure the real deployment and its registered public OAuth client once;
+neither value is a secret. No production management hostname is assumed.
+
+```bash
+summer config set platform.managementUrl https://management.example
+summer config set platform.oauthClientId summer-public-cli
+summer login --platform
+summer build publish . --version 1.0.0
+```
+
+The project must contain `project.godot` and `export_presets.cfg` at the
+declared directory. Local caches, `.env*`, and other machine state are always
+excluded; any remaining symlink or file changing during packaging fails the
+attempt before a draft is created. `--no-wait` returns once the sealed draft
+has been explicitly published and queued. A Release remains a separate,
+explicit operation.
+
 | Command | What it does |
 |---|---|
 | `summer install` | Download Summer Engine. Prints URL and size first. |
 | `summer login` | Browser-based core Summer sign-in. |
 | `summer login --creator` | Open Summercraft token settings and securely connect a separate publish-scoped creator token. |
+| `summer login --platform` | Sign in directly to the configured developer platform with Supabase OAuth 2.1 + PKCE. |
 | `summer logout` | Clear auth tokens. |
 | `summer config [get\|set\|unset]` | Read or update the shared non-secret `~/.summer/config.json`. |
+| `summer build publish [project] --version <value> [--no-wait]` | Draft, upload, seal, explicitly publish, and observe a hosted server Build through platform workers. Never deploys a Release. |
 | `summer publish [project] --artifact <game.pck> --version <value> [--confirm]` | Compute and show the exact immutable target; after approval, stream it through prepare → write-once PUT → finalize. |
 | `summer releases [--cursor <value>]` | List real creator-owned release history. |
 | `summer logs` | Read creator runtime logs. Fails closed while no durable runtime-log source exists. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "commander": "^12.0.0",
         "diff": "^7.0.0",
         "open": "^10.0.0",
+        "yazl": "^3.3.1",
         "zod": "^3.23.0"
       },
       "bin": {
@@ -23,6 +24,7 @@
       "devDependencies": {
         "@types/diff": "^7.0.0",
         "@types/node": "^20.0.0",
+        "@types/yazl": "^3.3.1",
         "typescript": "^5.5.0",
         "vitest": "^3.2.4"
       },
@@ -1000,6 +1002,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/yazl": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-DIWfCKpsTp6hE5BDBHV3+fIL/bLUF9Bv13iDrWnMlmhQpH67buNvI291ZauQ1xcccxK3FqQ9honnXpq4R8NMuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vercel/oidc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
@@ -1220,6 +1232,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/bundle-name": {
@@ -2992,6 +3013,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^1.0.0"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -80,11 +80,13 @@
     "commander": "^12.0.0",
     "diff": "^7.0.0",
     "open": "^10.0.0",
+    "yazl": "^3.3.1",
     "zod": "^3.23.0"
   },
   "devDependencies": {
     "@types/diff": "^7.0.0",
     "@types/node": "^20.0.0",
+    "@types/yazl": "^3.3.1",
     "typescript": "^5.5.0",
     "vitest": "^3.2.4"
   }

--- a/src/bin/summer.ts
+++ b/src/bin/summer.ts
@@ -23,6 +23,7 @@ import { configCommand } from "../commands/config.js";
 import { publishCommand } from "../commands/publish.js";
 import { releasesCommand } from "../commands/releases.js";
 import { logsCommand } from "../commands/logs.js";
+import { buildCommand } from "../commands/build.js";
 import { getBanner } from "../lib/banner.js";
 import { c, sym } from "../lib/format.js";
 
@@ -60,6 +61,7 @@ program.addCommand(configCommand);
 program.addCommand(publishCommand);
 program.addCommand(releasesCommand);
 program.addCommand(logsCommand);
+program.addCommand(buildCommand);
 
 program.parseAsync().catch((err) => {
   console.error(err instanceof Error ? err.message : String(err));

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,0 +1,28 @@
+import { Command } from "commander";
+import { publishBuild } from "../lib/build-publish.js";
+
+export const buildCommand = new Command("build").description(
+  "Create hosted game server Builds through the Summer platform"
+);
+
+buildCommand
+  .command("publish")
+  .description(
+    "Package source, seal and publish a BuildPublication draft, then wait for platform workers"
+  )
+  .argument("[project]", "Archive root containing summer.build.json. Defaults to the current directory.")
+  .requiredOption("--version <value>", "Immutable Build version")
+  .option("--no-wait", "Return after the draft is queued instead of waiting for the immutable Build")
+  .action(
+    async (
+      project: string | undefined,
+      opts: { version: string; wait: boolean }
+    ) => {
+      const result = await publishBuild({
+        project,
+        version: opts.version,
+        wait: opts.wait,
+      });
+      console.log(JSON.stringify(result, null, 2));
+    }
+  );

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -8,6 +8,7 @@ import {
   saveLoginSession,
 } from "../lib/auth.js";
 import { getCreatorApiUrl, getGatewayUrl } from "../lib/config.js";
+import { hasPlatformSession, runPlatformLogin } from "../lib/platform-auth.js";
 
 const POLL_INTERVAL_MS = 2000;
 // One generous window on ONE session id. First-time users may need to create an
@@ -24,8 +25,25 @@ export const loginCommand = new Command("login")
     "--creator",
     "Connect a separately scoped Summercraft creator token for publishing"
   )
+  .option(
+    "--platform",
+    "Sign in directly to the Summer developer platform with Supabase OAuth"
+  )
   .option("--force", "Force re-authentication even if already logged in")
-  .action(async (opts: { creator?: boolean; force?: boolean }) => {
+  .action(async (opts: { creator?: boolean; platform?: boolean; force?: boolean }) => {
+    if (opts.creator && opts.platform) {
+      throw new Error("Choose either --creator or --platform, not both.");
+    }
+    if (opts.platform) {
+      if ((await hasPlatformSession()) && !opts.force) {
+        console.log(
+          "A developer platform session already exists. Use --platform --force to replace it."
+        );
+        return;
+      }
+      await runPlatformLogin();
+      return;
+    }
     if (opts.creator) {
       const existingCreator = await getCreatorToken();
       if (existingCreator && !opts.force) {

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,10 +1,12 @@
 import { Command } from "commander";
 import { clearAuthCredentials } from "../lib/auth.js";
+import { clearPlatformSession } from "../lib/platform-auth.js";
 
 export const logoutCommand = new Command("logout")
   .description("Sign out and clear stored auth tokens")
   .action(async () => {
-    const removed = await clearAuthCredentials();
+    const removed =
+      (await clearAuthCredentials()) + ((await clearPlatformSession()) ? 1 : 0);
     if (removed > 0) {
       console.log("Logged out. Auth tokens cleared.");
     } else {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -3,6 +3,7 @@ import { getAuthToken, getUserInfo } from "../lib/auth.js";
 import { getApiToken, getApiPort, checkEngineHealth } from "../lib/engine.js";
 import { getProjectMemorySummary } from "../lib/project-memory.js";
 import { formatStatusMemoryLine } from "./memory.js";
+import { hasPlatformSession } from "../lib/platform-auth.js";
 
 export const statusCommand = new Command("status")
   .description("Check Summer Engine status, connection, and auth state")
@@ -18,6 +19,10 @@ export const statusCommand = new Command("status")
       console.log("        Run: npx summer-engine login");
       console.log("        Or: https://www.summerengine.com/login");
     }
+
+    console.log(
+      `  Developer platform: ${(await hasPlatformSession()) ? "Session stored" : "Not signed in"}`
+    );
 
     const apiToken = await getApiToken();
     const port = await getApiPort();

--- a/src/lib/build-publish.test.ts
+++ b/src/lib/build-publish.test.ts
@@ -1,0 +1,328 @@
+import { readFile, mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createSourceArchive,
+  loadBuildProjectConfig,
+  publishBuild,
+} from "./build-publish.js";
+
+let root = "";
+
+async function writeProject(): Promise<void> {
+  await writeFile(join(root, "project.godot"), "[application]\nconfig/name=\"Test\"\n");
+  await writeFile(
+    join(root, "export_presets.cfg"),
+    '[preset.0]\nname="Summer Dedicated Server"\n'
+  );
+  await writeFile(join(root, "main.tscn"), "[gd_scene format=3]\n");
+  await writeFile(
+    join(root, "summer.build.json"),
+    `${JSON.stringify(
+      {
+        schema: "summer.build.v1",
+        gameId: "game_test",
+        project: { directory: "." },
+        server: { exportPreset: "Summer Dedicated Server" },
+        runtime: {
+          protocolVersion: "1",
+          scenes: ["res://main.tscn"],
+          queues: [],
+        },
+      },
+      null,
+      2
+    )}\n`
+  );
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "summer-build-publish-test-"));
+  await writeProject();
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("source archive", () => {
+  it("is deterministic and excludes local credentials and caches", async () => {
+    await writeFile(join(root, ".env.local"), "DO_NOT_UPLOAD=secret\n");
+    await mkdir(join(root, ".godot"));
+    await writeFile(join(root, ".godot", "cache"), "machine state");
+
+    const first = await createSourceArchive(root);
+    const firstBytes = await readFile(first.path);
+    const firstDigest = first.sha256;
+    await first.cleanup();
+    const second = await createSourceArchive(root);
+    const secondBytes = await readFile(second.path);
+
+    expect(second.sha256).toBe(firstDigest);
+    expect(secondBytes.equals(firstBytes)).toBe(true);
+    expect(secondBytes.includes(Buffer.from(".env.local"))).toBe(false);
+    expect(secondBytes.includes(Buffer.from("DO_NOT_UPLOAD"))).toBe(false);
+    expect(secondBytes.includes(Buffer.from(".godot/cache"))).toBe(false);
+    expect(secondBytes.includes(Buffer.from("project.godot"))).toBe(true);
+    expect(secondBytes.includes(Buffer.from("summer.build.json"))).toBe(true);
+    await second.cleanup();
+  });
+
+  it("fails closed on symlinks instead of silently dropping source", async () => {
+    await symlink(join(root, "main.tscn"), join(root, "linked.tscn"));
+    await expect(createSourceArchive(root)).rejects.toThrow(/cannot contain symlinks/i);
+  });
+
+  it("requires a strict stable declaration and dedicated export files", async () => {
+    const config = await loadBuildProjectConfig(root);
+    expect(config.gameId).toBe("game_test");
+    await rm(join(root, "export_presets.cfg"));
+    await expect(createSourceArchive(root, config)).rejects.toThrow(/export_presets\.cfg was not found/);
+  });
+
+  it("refuses an ignore rule that removes a required build input", async () => {
+    await writeFile(join(root, ".summercloudignore"), "export_presets.cfg\n");
+    await expect(createSourceArchive(root)).rejects.toThrow(
+      /export_presets\.cfg is excluded/
+    );
+  });
+});
+
+async function readRequestBody(body: BodyInit | null | undefined): Promise<Buffer> {
+  if (typeof body === "string") return Buffer.from(body);
+  if (body instanceof URLSearchParams) return Buffer.from(body.toString());
+  const chunks: Buffer[] = [];
+  for await (const chunk of body as unknown as AsyncIterable<Buffer | Uint8Array>) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+function headerValue(init: RequestInit | undefined, name: string): string | null {
+  return new Headers(init?.headers).get(name);
+}
+
+describe("platform BuildPublication flow", () => {
+  it("uses draft -> upload -> seal -> publish -> worker result without creating a Release", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    let createBody: {
+      source: { sizeBytes: number; archiveSha256: string };
+      build: Record<string, unknown>;
+    } | null = null;
+    let publicationReads = 0;
+    let uploadedBytes = 0;
+    let managementTokenReads = 0;
+
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (url === "https://management.example/v1/management/games/game_test/build-publications") {
+        createBody = JSON.parse(String(init?.body));
+        expect(init?.method).toBe("POST");
+        expect(headerValue(init, "authorization")).toMatch(
+          /^Bearer developer-token-[0-9]+$/
+        );
+        expect(headerValue(init, "idempotency-key")).toMatch(/^buildpub-[0-9a-f]{64}$/);
+        return Response.json(
+          {
+            operationId: "op_1",
+            publicationId: "buildpub_1",
+            buildId: "build_1",
+            sourceId: "buildsrc_1",
+            state: "uploading",
+          },
+          { status: 202 }
+        );
+      }
+      if (url.endsWith("/build-publications/buildpub_1:source-upload")) {
+        return Response.json({
+          sourceId: "buildsrc_1",
+          upload: {
+            method: "PUT",
+            url: "https://objects.example/one-use?signature=test",
+            headers: {
+              "Content-Length": String(createBody!.source.sizeBytes),
+              "Content-Type": "application/zip",
+              "If-None-Match": "*",
+            },
+            expiresAt: "1970-01-01T00:10:00Z",
+          },
+        });
+      }
+      if (url.startsWith("https://objects.example/one-use")) {
+        expect(headerValue(init, "authorization")).toBeNull();
+        expect(headerValue(init, "if-none-match")).toBe("*");
+        uploadedBytes = (await readRequestBody(init?.body)).length;
+        return new Response(null, { status: 200 });
+      }
+      if (url.endsWith("/build-publications/buildpub_1:source-complete")) {
+        expect(headerValue(init, "authorization")).toMatch(
+          /^Bearer developer-token-[0-9]+$/
+        );
+        expect(headerValue(init, "idempotency-key")).toMatch(/^buildsrc-[0-9a-f]{64}$/);
+        return new Response(null, { status: 204 });
+      }
+      if (url.endsWith("/build-publications/buildpub_1:publish")) {
+        expect(headerValue(init, "authorization")).toMatch(
+          /^Bearer developer-token-[0-9]+$/
+        );
+        expect(headerValue(init, "idempotency-key")).toMatch(
+          /^buildpublish-[0-9a-f]{64}$/
+        );
+        return Response.json(
+          {
+            operationId: "op_1",
+            publicationId: "buildpub_1",
+            buildId: "build_1",
+            sourceId: "buildsrc_1",
+            state: "pending",
+          },
+          { status: 202 }
+        );
+      }
+      if (url.endsWith("/build-publications/buildpub_1")) {
+        publicationReads += 1;
+        const state =
+          publicationReads === 1
+            ? "uploading"
+            : publicationReads === 2
+              ? "building"
+              : "succeeded";
+        return Response.json({
+          id: "buildpub_1",
+          operationId: "op_1",
+          gameId: "game_test",
+          buildId: "build_1",
+          version: "1.2.3",
+          state,
+        });
+      }
+      if (url.endsWith("/builds/build_1")) {
+        return Response.json({
+          id: "build_1",
+          gameId: "game_test",
+          version: "1.2.3",
+          artifactSha256: `sha256:${"a".repeat(64)}`,
+          serverImage: `registry.example/game@sha256:${"b".repeat(64)}`,
+          status: "ready",
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    let now = 0;
+    const result = await publishBuild(
+      { project: root, version: "1.2.3", pollIntervalMs: 1 },
+      {
+        fetch: fetchMock as typeof fetch,
+        managementUrl: async () => "https://management.example",
+        managementToken: async () =>
+          `developer-token-${++managementTokenReads}`,
+        sleep: async (ms) => {
+          now += ms;
+        },
+        now: () => now,
+        log: () => undefined,
+      }
+    );
+
+    expect(createBody!.build).toEqual({
+      schema: "summer.build.v1",
+      version: "1.2.3",
+      project: { directory: "." },
+      server: { exportPreset: "Summer Dedicated Server" },
+      runtime: {
+        protocolVersion: "1",
+        scenes: ["res://main.tscn"],
+        queues: [],
+      },
+    });
+    expect(uploadedBytes).toBe(createBody!.source.sizeBytes);
+    expect(result).toMatchObject({
+      publicationId: "buildpub_1",
+      buildId: "build_1",
+      state: "succeeded",
+      build: { status: "ready" },
+    });
+    expect(calls.some(({ url }) => url.includes("/releases"))).toBe(false);
+    const managementCalls = calls.filter(({ url }) =>
+      url.startsWith("https://management.example/")
+    );
+    expect(managementTokenReads).toBe(managementCalls.length);
+    expect(
+      new Set(
+        managementCalls.map(({ init }) => headerValue(init, "authorization"))
+      ).size
+    ).toBe(managementCalls.length);
+  });
+
+  it("requires a real configured management origin", async () => {
+    await expect(
+      publishBuild(
+        { project: root, version: "1.0.0" },
+        {
+          managementUrl: async () => null,
+          managementToken: async () => "unused",
+          log: () => undefined,
+        }
+      )
+    ).rejects.toThrow(/No management API is configured/);
+  });
+
+  it("resumes a sealed draft at the explicit publish boundary", async () => {
+    const calls: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.endsWith("/build-publications")) {
+        return Response.json(
+          {
+            operationId: "op_resume",
+            publicationId: "buildpub_resume",
+            buildId: "build_resume",
+            sourceId: "buildsrc_resume",
+            state: "uploading",
+          },
+          { status: 202 }
+        );
+      }
+      if (url.endsWith("/build-publications/buildpub_resume")) {
+        return Response.json({
+          id: "buildpub_resume",
+          operationId: "op_resume",
+          gameId: "game_test",
+          version: "2.0.0",
+          state: "draft",
+        });
+      }
+      if (url.endsWith("/build-publications/buildpub_resume:publish")) {
+        return Response.json(
+          {
+            operationId: "op_resume",
+            publicationId: "buildpub_resume",
+            buildId: "build_resume",
+            sourceId: "buildsrc_resume",
+            state: "pending",
+          },
+          { status: 202 }
+        );
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    const result = await publishBuild(
+      { project: root, version: "2.0.0", wait: false },
+      {
+        fetch: fetchMock as typeof fetch,
+        managementUrl: async () => "https://management.example",
+        managementToken: async () => "developer-token",
+        log: () => undefined,
+      }
+    );
+
+    expect(result.state).toBe("pending");
+    expect(calls.some((url) => url.includes(":source-upload"))).toBe(false);
+    expect(calls.some((url) => url.endsWith(":publish"))).toBe(true);
+  });
+});

--- a/src/lib/build-publish.ts
+++ b/src/lib/build-publish.ts
@@ -1,0 +1,727 @@
+import { createHash } from "node:crypto";
+import {
+  createReadStream,
+  createWriteStream,
+  type BigIntStats,
+} from "node:fs";
+import { lstat, mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, posix, resolve } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { ZipFile } from "yazl";
+import { walkProject } from "./cloud/hash.js";
+import { getManagementToken } from "./platform-auth.js";
+import { getManagementUrl } from "./config.js";
+
+const BUILD_CONFIG_FILE = "summer.build.json";
+const MAX_CONFIG_BYTES = 64 * 1024;
+const MAX_ARCHIVE_BYTES = 2 * 1024 * 1024 * 1024;
+const FIXED_ZIP_TIME = new Date("1980-01-01T00:00:00.000Z");
+const ACTIVE_STATES = new Set([
+  "uploading",
+  "pending",
+  "materializing",
+  "building",
+  "publishing",
+  "verifying",
+]);
+
+export interface BuildProjectConfig {
+  schema: "summer.build.v1" | "summer.build.v2";
+  gameId: string;
+  engineVersion?: string;
+  sdkVersion?: string;
+  project: { directory: string };
+  server: { exportPreset: string };
+  runtime: Record<string, unknown>;
+}
+
+export interface SourceArchive {
+  path: string;
+  sha256: string;
+  sizeBytes: number;
+  fileCount: number;
+  cleanup: () => Promise<void>;
+}
+
+interface BuildPublicationAccepted {
+  operationId: string;
+  publicationId: string;
+  buildId: string;
+  sourceId: string;
+  state: "uploading" | "pending";
+}
+
+interface BuildPublication {
+  id: string;
+  operationId: string;
+  gameId: string;
+  buildId?: string;
+  version: string;
+  state: string;
+  progress?: Record<string, unknown>;
+  errorCode?: string;
+  errorMessage?: string;
+}
+
+interface PublishedBuild {
+  id: string;
+  gameId: string;
+  version: string;
+  artifactSha256: string;
+  serverImage: string;
+  status: string;
+}
+
+interface UploadGrant {
+  sourceId: string;
+  upload: {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    expiresAt: string;
+  };
+}
+
+export interface PublishBuildOptions {
+  project?: string;
+  version: string;
+  wait?: boolean;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+}
+
+export interface PublishBuildResult {
+  gameId: string;
+  version: string;
+  publicationId: string;
+  operationId: string;
+  buildId: string;
+  state: string;
+  archiveSha256: string;
+  archiveSizeBytes: number;
+  build?: PublishedBuild;
+}
+
+export interface PublishBuildDependencies {
+  fetch: typeof fetch;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+  log: (message: string) => void;
+  managementUrl: () => Promise<string | null>;
+  managementToken: () => Promise<string>;
+}
+
+const defaultDependencies: PublishBuildDependencies = {
+  fetch,
+  sleep: (ms) => new Promise((resolvePromise) => setTimeout(resolvePromise, ms)),
+  now: Date.now,
+  log: console.log,
+  managementUrl: getManagementUrl,
+  managementToken: getManagementToken,
+};
+
+function record(value: unknown, name: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be a JSON object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  name: string
+): void {
+  const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
+  if (unknown.length) {
+    throw new Error(`${name} contains unknown field${unknown.length === 1 ? "" : "s"}: ${unknown.join(", ")}.`);
+  }
+}
+
+function token(value: unknown, name: string): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > 128 ||
+    value.trim() !== value ||
+    /[\0\r\n]/.test(value)
+  ) {
+    throw new Error(`${name} must be a non-empty, trimmed value of at most 128 characters.`);
+  }
+  return value;
+}
+
+function projectDirectory(value: unknown): string {
+  const directory = token(value, "project.directory");
+  if (
+    directory !== "." &&
+    (isAbsolute(directory) ||
+      directory.includes("\\") ||
+      directory === ".." ||
+      directory.startsWith("../") ||
+      directory.split("/").includes("..") ||
+      posix.normalize(directory) !== directory)
+  ) {
+    throw new Error("project.directory must be '.' or a safe slash-separated relative path.");
+  }
+  return directory;
+}
+
+export async function loadBuildProjectConfig(
+  archiveRoot: string
+): Promise<BuildProjectConfig> {
+  const configPath = join(archiveRoot, BUILD_CONFIG_FILE);
+  let info;
+  try {
+    info = await lstat(configPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(
+        `${BUILD_CONFIG_FILE} was not found in ${archiveRoot}. Add the game's stable server/runtime declaration and retry.`
+      );
+    }
+    throw error;
+  }
+  if (!info.isFile() || info.isSymbolicLink() || info.size > MAX_CONFIG_BYTES) {
+    throw new Error(`${configPath} must be a regular JSON file no larger than ${MAX_CONFIG_BYTES} bytes.`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(configPath, "utf8"));
+  } catch {
+    throw new Error(`${configPath} is not valid JSON.`);
+  }
+  const root = record(parsed, BUILD_CONFIG_FILE);
+  exactKeys(
+    root,
+    [
+      "schema",
+      "gameId",
+      "engineVersion",
+      "sdkVersion",
+      "project",
+      "server",
+      "runtime",
+    ],
+    BUILD_CONFIG_FILE
+  );
+  if (root.schema !== "summer.build.v1" && root.schema !== "summer.build.v2") {
+    throw new Error('summer.build.json schema must be "summer.build.v1" or "summer.build.v2".');
+  }
+  const project = record(root.project, "project");
+  exactKeys(project, ["directory"], "project");
+  const server = record(root.server, "server");
+  exactKeys(server, ["exportPreset"], "server");
+  const runtime = record(root.runtime, "runtime");
+  token(runtime.protocolVersion, "runtime.protocolVersion");
+  if (!Array.isArray(runtime.scenes) || runtime.scenes.length === 0) {
+    throw new Error("runtime.scenes must contain at least one scene.");
+  }
+  for (const [index, scene] of runtime.scenes.entries()) {
+    token(scene, `runtime.scenes[${index}]`);
+  }
+  if (runtime.queues !== undefined && !Array.isArray(runtime.queues)) {
+    throw new Error("runtime.queues must be an array when present.");
+  }
+
+  const gameId = token(root.gameId, "gameId");
+  if (!/^[A-Za-z0-9_-]{1,160}$/.test(gameId)) {
+    throw new Error("gameId may contain only letters, numbers, underscores, and hyphens.");
+  }
+  const exportPreset = token(server.exportPreset, "server.exportPreset");
+  if (!/^[A-Za-z0-9][A-Za-z0-9 ._-]{0,127}$/.test(exportPreset)) {
+    throw new Error("server.exportPreset is not a valid Summer export preset name.");
+  }
+
+  const config: BuildProjectConfig = {
+    schema: root.schema,
+    gameId,
+    project: { directory: projectDirectory(project.directory) },
+    server: { exportPreset },
+    runtime,
+  };
+  if (root.engineVersion !== undefined) {
+    config.engineVersion = token(root.engineVersion, "engineVersion");
+  }
+  if (root.sdkVersion !== undefined) {
+    config.sdkVersion = token(root.sdkVersion, "sdkVersion");
+  }
+  return config;
+}
+
+function expectedProjectFile(
+  archiveRoot: string,
+  directory: string,
+  fileName: string
+): string {
+  return directory === "."
+    ? join(archiveRoot, fileName)
+    : join(archiveRoot, ...directory.split("/"), fileName);
+}
+
+async function requireRegularFile(path: string, label: string): Promise<void> {
+  let info;
+  try {
+    info = await lstat(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`${label} was not found at ${path}.`);
+    }
+    throw error;
+  }
+  if (!info.isFile() || info.isSymbolicLink()) {
+    throw new Error(`${label} must be a regular file, not a directory or symlink.`);
+  }
+}
+
+function compareCapturedStat(
+  key: string,
+  before: { size: number; mtimeNs: string; inode: string },
+  after: BigIntStats
+): void {
+  if (
+    after.size !== BigInt(before.size) ||
+    after.ino.toString() !== before.inode ||
+    after.mtimeNs.toString() !== before.mtimeNs
+  ) {
+    throw new Error(`${key} changed while it was being packaged. Save the project and retry.`);
+  }
+}
+
+export async function createSourceArchive(
+  project: string | undefined,
+  config?: BuildProjectConfig
+): Promise<SourceArchive> {
+  const archiveRoot = resolve(project ?? process.cwd());
+  const rootInfo = await lstat(archiveRoot).catch(() => null);
+  if (!rootInfo?.isDirectory() || rootInfo.isSymbolicLink()) {
+    throw new Error(`Project root ${archiveRoot} must be a real directory.`);
+  }
+  const declaration = config ?? (await loadBuildProjectConfig(archiveRoot));
+  await requireRegularFile(
+    expectedProjectFile(archiveRoot, declaration.project.directory, "project.godot"),
+    "project.godot"
+  );
+  await requireRegularFile(
+    expectedProjectFile(
+      archiveRoot,
+      declaration.project.directory,
+      "export_presets.cfg"
+    ),
+    "export_presets.cfg"
+  );
+
+  const walked = await walkProject(archiveRoot, { noCache: true });
+  if (walked.skippedSymlinks.length) {
+    throw new Error(
+      `The source archive cannot contain symlinks. Replace or exclude: ${walked.skippedSymlinks.join(", ")}.`
+    );
+  }
+  if (walked.unstablePaths.length) {
+    throw new Error(
+      `Files kept changing while they were read. Save the project and retry: ${walked.unstablePaths.join(", ")}.`
+    );
+  }
+  const keys = Object.keys(walked.files).sort((left, right) =>
+    Buffer.from(left).compare(Buffer.from(right))
+  );
+  if (!keys.length) throw new Error("The project has no publishable files.");
+  const projectPrefix =
+    declaration.project.directory === "."
+      ? ""
+      : `${declaration.project.directory}/`;
+  for (const required of ["project.godot", "export_presets.cfg"]) {
+    const key = `${projectPrefix}${required}`;
+    if (!walked.files[key]) {
+      throw new Error(
+        `${key} is excluded from the source archive. Remove that ignore rule and retry.`
+      );
+    }
+  }
+
+  const temporaryRoot = await mkdtemp(join(tmpdir(), "summer-build-publish-"));
+  const archivePath = join(temporaryRoot, "source.zip");
+  try {
+    const zip = new ZipFile();
+    for (const key of keys) {
+      zip.addFile(walked.diskPathByKey.get(key)!, key, {
+        compress: true,
+        mtime: FIXED_ZIP_TIME,
+        mode: 0o100644,
+      });
+    }
+    const completed = pipeline(
+      zip.outputStream,
+      createWriteStream(archivePath, { flags: "wx", mode: 0o600 })
+    );
+    zip.end({ forceZip64Format: false, comment: "" });
+    await completed;
+
+    for (const key of keys) {
+      const captured = walked.statByKey.get(key)!;
+      const diskPath = walked.diskPathByKey.get(key)!;
+      compareCapturedStat(key, captured, await stat(diskPath, { bigint: true }));
+    }
+
+    const hash = createHash("sha256");
+    let sizeBytes = 0;
+    for await (const chunk of createReadStream(archivePath)) {
+      const bytes = chunk as Buffer;
+      sizeBytes += bytes.length;
+      if (sizeBytes > MAX_ARCHIVE_BYTES) {
+        throw new Error("The source ZIP exceeds the platform 2 GiB limit.");
+      }
+      hash.update(bytes);
+    }
+    if (sizeBytes === 0) throw new Error("The source ZIP is empty.");
+    return {
+      path: archivePath,
+      sha256: `sha256:${hash.digest("hex")}`,
+      sizeBytes,
+      fileCount: keys.length,
+      cleanup: async () => rm(temporaryRoot, { recursive: true, force: true }),
+    };
+  } catch (error) {
+    await rm(temporaryRoot, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function managementOrigin(value: string | null): string {
+  if (!value) {
+    throw new Error(
+      'No management API is configured. Run "summer config set platform.managementUrl https://<the-declared-management-origin>" and retry.'
+    );
+  }
+  return value;
+}
+
+function requestKey(prefix: string, ...values: string[]): string {
+  return `${prefix}-${createHash("sha256").update(values.join("\0")).digest("hex")}`;
+}
+
+async function responseError(response: Response, action: string): Promise<Error> {
+  const requestId = response.headers.get("x-request-id");
+  let detail = "";
+  try {
+    const body = (await response.json()) as {
+      error?: { code?: string; message?: string } | string;
+      code?: string;
+      message?: string;
+    };
+    if (typeof body.error === "string") detail = body.error;
+    else detail = body.error?.message ?? body.message ?? body.error?.code ?? body.code ?? "";
+  } catch {
+    // Error bodies are optional and never trusted as control data.
+  }
+  return new Error(
+    `${action} failed (${response.status})${detail ? `: ${detail}` : ""}${requestId ? ` [request ${requestId}]` : ""}`
+  );
+}
+
+async function managementRequest<T>(
+  deps: PublishBuildDependencies,
+  origin: string,
+  path: string,
+  init: RequestInit = {}
+): Promise<{ response: Response; body: T }> {
+  // Resolve the session for every management exchange. Hosted builds can run
+  // long enough for an otherwise-valid access token to expire while an upload
+  // or worker poll is in progress; the auth layer refreshes it when needed.
+  const tokenValue = await deps.managementToken();
+  const response = await deps.fetch(`${origin}${path}`, {
+    ...init,
+    redirect: "error",
+    signal: init.signal ?? AbortSignal.timeout(30_000),
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${tokenValue}`,
+      ...init.headers,
+    },
+  });
+  if (!response.ok) throw await responseError(response, `${init.method ?? "GET"} ${path}`);
+  return { response, body: (await response.json()) as T };
+}
+
+function validateUploadGrant(
+  grant: UploadGrant,
+  archive: SourceArchive,
+  now: number
+): void {
+  if (grant.upload.method !== "PUT") {
+    throw new Error(`The platform returned unsupported upload method ${grant.upload.method}.`);
+  }
+  let target: URL;
+  try {
+    target = new URL(grant.upload.url);
+  } catch {
+    throw new Error("The platform returned an invalid upload URL.");
+  }
+  const local =
+    target.hostname === "localhost" ||
+    target.hostname === "127.0.0.1" ||
+    target.hostname === "::1";
+  if (target.protocol !== "https:" && !(local && target.protocol === "http:")) {
+    throw new Error("The platform upload URL must use HTTPS (except literal loopback development). ");
+  }
+  if (target.username || target.password || target.hash) {
+    throw new Error("The platform returned an unsafe upload URL.");
+  }
+  const expiresAt = Date.parse(grant.upload.expiresAt);
+  if (
+    !Number.isFinite(expiresAt) ||
+    expiresAt <= now + 5_000 ||
+    expiresAt > now + 16 * 60_000
+  ) {
+    throw new Error("The platform returned an invalid or expired upload grant.");
+  }
+  const seenHeaders = new Set<string>();
+  for (const [name, value] of Object.entries(grant.upload.headers)) {
+    const lower = name.toLowerCase();
+    if (
+      seenHeaders.has(lower) ||
+      lower === "authorization" ||
+      lower === "cookie" ||
+      lower === "proxy-authorization" ||
+      /[\r\n]/.test(name) ||
+      /[\r\n]/.test(value)
+    ) {
+      throw new Error(`The platform returned forbidden upload header ${name}.`);
+    }
+    seenHeaders.add(lower);
+  }
+  const header = (name: string) =>
+    Object.entries(grant.upload.headers).find(
+      ([candidate]) => candidate.toLowerCase() === name
+    )?.[1];
+  const length = header("content-length");
+  if (length !== String(archive.sizeBytes)) {
+    throw new Error("The platform upload grant does not match the exact archive size.");
+  }
+  if (header("content-type")?.toLowerCase() !== "application/zip") {
+    throw new Error("The platform upload grant does not bind application/zip.");
+  }
+  if (header("if-none-match") !== "*") {
+    throw new Error("The platform upload grant is not write-once.");
+  }
+}
+
+async function uploadArchive(
+  deps: PublishBuildDependencies,
+  grant: UploadGrant,
+  archive: SourceArchive
+): Promise<void> {
+  validateUploadGrant(grant, archive, deps.now());
+  const init = {
+    method: "PUT",
+    redirect: "error" as const,
+    headers: grant.upload.headers,
+    body: createReadStream(archive.path) as unknown as BodyInit,
+    duplex: "half" as const,
+    signal: AbortSignal.timeout(10 * 60_000),
+  };
+  const response = await deps.fetch(grant.upload.url, init as RequestInit);
+  if (!response.ok && response.status !== 412) {
+    throw await responseError(response, "Source upload");
+  }
+}
+
+function publicationPath(gameId: string, publicationId?: string): string {
+  const base = `/v1/management/games/${encodeURIComponent(gameId)}/build-publications`;
+  return publicationId ? `${base}/${encodeURIComponent(publicationId)}` : base;
+}
+
+function buildIntent(config: BuildProjectConfig, version: string): Record<string, unknown> {
+  return {
+    schema: config.schema,
+    version: token(version, "version"),
+    ...(config.engineVersion ? { engineVersion: config.engineVersion } : {}),
+    ...(config.sdkVersion ? { sdkVersion: config.sdkVersion } : {}),
+    project: config.project,
+    server: config.server,
+    runtime: config.runtime,
+  };
+}
+
+export async function publishBuild(
+  options: PublishBuildOptions,
+  overrides: Partial<PublishBuildDependencies> = {}
+): Promise<PublishBuildResult> {
+  const deps = { ...defaultDependencies, ...overrides };
+  const archiveRoot = resolve(options.project ?? process.cwd());
+  const config = await loadBuildProjectConfig(archiveRoot);
+  const version = token(options.version, "version");
+  const origin = managementOrigin(await deps.managementUrl());
+  const archive = await createSourceArchive(archiveRoot, config);
+  try {
+    deps.log(
+      `Packaged ${archive.fileCount} files (${archive.sizeBytes} bytes, ${archive.sha256}).`
+    );
+    const body = JSON.stringify({
+      source: {
+        kind: "platform-upload",
+        archiveSha256: archive.sha256,
+        sizeBytes: archive.sizeBytes,
+      },
+      build: buildIntent(config, version),
+    });
+    const createKey = requestKey("buildpub", config.gameId, body);
+    const accepted = (
+      await managementRequest<BuildPublicationAccepted>(
+        deps,
+        origin,
+        publicationPath(config.gameId),
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Idempotency-Key": createKey,
+          },
+          body,
+        }
+      )
+    ).body;
+    deps.log(`Draft ${accepted.publicationId} created for Build ${accepted.buildId}.`);
+
+    let publication = (
+      await managementRequest<BuildPublication>(
+        deps,
+        origin,
+        publicationPath(config.gameId, accepted.publicationId)
+      )
+    ).body;
+    if (publication.state === "uploading") {
+      const grant = (
+        await managementRequest<UploadGrant>(
+          deps,
+          origin,
+          `${publicationPath(config.gameId, accepted.publicationId)}:source-upload`,
+          { method: "POST" }
+        )
+      ).body;
+      if (grant.sourceId !== accepted.sourceId) {
+        throw new Error("The upload grant source identity does not match the draft.");
+      }
+      await uploadArchive(deps, grant, archive);
+      deps.log("Source uploaded; sealing the draft.");
+      const completePath = `${publicationPath(config.gameId, accepted.publicationId)}:source-complete`;
+      const complete = await deps.fetch(`${origin}${completePath}`, {
+        method: "POST",
+        redirect: "error",
+        signal: AbortSignal.timeout(30_000),
+        headers: {
+          Authorization: `Bearer ${await deps.managementToken()}`,
+          "Idempotency-Key": requestKey(
+            "buildsrc",
+            config.gameId,
+            accepted.publicationId,
+            archive.sha256
+          ),
+        },
+      });
+      if (!complete.ok) throw await responseError(complete, "Source completion");
+      publication = {
+        ...publication,
+        state: "draft",
+      };
+    }
+
+    if (publication.state === "draft") {
+      deps.log("Draft sealed; publishing it to platform workers.");
+      const publishPath = `${publicationPath(config.gameId, accepted.publicationId)}:publish`;
+      const published = (
+        await managementRequest<BuildPublicationAccepted>(
+          deps,
+          origin,
+          publishPath,
+          {
+            method: "POST",
+            headers: {
+              "Idempotency-Key": requestKey(
+                "buildpublish",
+                config.gameId,
+                accepted.publicationId,
+                accepted.buildId,
+                archive.sha256
+              ),
+            },
+          }
+        )
+      ).body;
+      if (
+        published.publicationId !== accepted.publicationId ||
+        published.operationId !== accepted.operationId ||
+        published.buildId !== accepted.buildId ||
+        published.sourceId !== accepted.sourceId ||
+        published.state !== "pending"
+      ) {
+        throw new Error("The published draft identities do not match the source draft.");
+      }
+      publication = { ...publication, state: "pending" };
+    }
+
+    const baseResult: PublishBuildResult = {
+      gameId: config.gameId,
+      version,
+      publicationId: accepted.publicationId,
+      operationId: accepted.operationId,
+      buildId: accepted.buildId,
+      state: publication.state,
+      archiveSha256: archive.sha256,
+      archiveSizeBytes: archive.sizeBytes,
+    };
+    if (options.wait === false) return baseResult;
+
+    const startedAt = deps.now();
+    const timeoutMs = options.timeoutMs ?? 30 * 60_000;
+    const pollIntervalMs = options.pollIntervalMs ?? 2_000;
+    let lastState = "";
+    while (deps.now() - startedAt < timeoutMs) {
+      publication = (
+        await managementRequest<BuildPublication>(
+          deps,
+          origin,
+          publicationPath(config.gameId, accepted.publicationId)
+        )
+      ).body;
+      if (publication.state !== lastState) {
+        lastState = publication.state;
+        deps.log(`Platform publication: ${publication.state}.`);
+      }
+      if (publication.state === "failed") {
+        throw new Error(
+          `Platform workers rejected the build${publication.errorCode ? ` (${publication.errorCode})` : ""}${publication.errorMessage ? `: ${publication.errorMessage}` : "."}`
+        );
+      }
+      if (publication.state === "succeeded") {
+        const build = (
+          await managementRequest<PublishedBuild>(
+            deps,
+            origin,
+            `/v1/management/games/${encodeURIComponent(config.gameId)}/builds/${encodeURIComponent(accepted.buildId)}`
+          )
+        ).body;
+        if (
+          build.id !== accepted.buildId ||
+          build.gameId !== config.gameId ||
+          build.version !== version ||
+          build.status !== "ready"
+        ) {
+          throw new Error("The platform returned a Build that does not match the submitted draft.");
+        }
+        return { ...baseResult, state: "succeeded", build };
+      }
+      if (!ACTIVE_STATES.has(publication.state)) {
+        throw new Error(`The platform returned unknown publication state ${publication.state}.`);
+      }
+      await deps.sleep(pollIntervalMs);
+    }
+    throw new Error(
+      `Timed out waiting for ${accepted.publicationId}. The draft remains durable; rerun the same command to resume it.`
+    );
+  } finally {
+    await archive.cleanup();
+  }
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,6 +3,8 @@ import { readStoreJson, writeStoreJson } from "./store.js";
 const CONFIG_FILE = "config.json";
 const DEFAULT_GATEWAY_URL = "https://www.summerengine.com";
 const DEFAULT_CREATOR_API_URL = "https://summercraft.ai";
+const DEFAULT_DEVELOPER_OAUTH_ISSUER =
+  "https://bjhcdenhsahdyirbbzlx.supabase.co/auth/v1";
 
 export interface SummerConfig {
   schemaVersion: 1;
@@ -14,6 +16,11 @@ export interface SummerConfig {
     projectId?: string;
     channel?: string;
   };
+  platform?: {
+    managementUrl?: string;
+    oauthIssuer?: string;
+    oauthClientId?: string;
+  };
 }
 
 export const CONFIG_KEYS = [
@@ -21,6 +28,9 @@ export const CONFIG_KEYS = [
   "creator.apiUrl",
   "creator.projectId",
   "creator.channel",
+  "platform.managementUrl",
+  "platform.oauthIssuer",
+  "platform.oauthClientId",
 ] as const;
 
 export type ConfigKey = (typeof CONFIG_KEYS)[number];
@@ -98,6 +108,57 @@ function validateCreatorApiUrl(value: string): string {
   return parsed.origin;
 }
 
+function validateOrigin(key: string, value: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${key} must be a complete URL.`);
+  }
+  const local =
+    parsed.hostname === "localhost" ||
+    parsed.hostname === "127.0.0.1" ||
+    parsed.hostname === "::1";
+  if (parsed.protocol !== "https:" && !(local && parsed.protocol === "http:")) {
+    throw new Error(
+      `${key} must use HTTPS (HTTP is allowed only for localhost).`
+    );
+  }
+  if (
+    parsed.username ||
+    parsed.password ||
+    parsed.pathname !== "/" ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw new Error(
+      `${key} must be an origin without credentials, a path, query parameters, or fragments.`
+    );
+  }
+  return parsed.origin;
+}
+
+function validateIssuer(value: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error("platform.oauthIssuer must be a complete HTTPS URL.");
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw new Error(
+      "platform.oauthIssuer must be a complete HTTPS URL without credentials, query parameters, or fragments."
+    );
+  }
+  return parsed.toString().replace(/\/+$/, "");
+}
+
 function validateValue(key: ConfigKey, value: string): string {
   const clean = value.trim();
   if (!clean) {
@@ -107,6 +168,14 @@ function validateValue(key: ConfigKey, value: string): string {
   }
   if (key === "gateway.url") return validateGatewayUrl(clean);
   if (key === "creator.apiUrl") return validateCreatorApiUrl(clean);
+  if (key === "platform.managementUrl") return validateOrigin(key, clean);
+  if (key === "platform.oauthIssuer") return validateIssuer(clean);
+  if (
+    key === "platform.oauthClientId" &&
+    !/^[A-Za-z0-9._~-]{8,256}$/.test(clean)
+  ) {
+    throw new Error("platform.oauthClientId is not a valid public OAuth client ID.");
+  }
   if (key === "creator.channel" && !/^[a-z0-9][a-z0-9._-]{0,63}$/i.test(clean)) {
     throw new Error(
       "creator.channel may contain letters, numbers, dots, underscores, and hyphens. Recovery: choose a channel such as production or preview."
@@ -127,7 +196,10 @@ export function getConfigValue(
   if (key === "gateway.url") return config.gateway?.url;
   if (key === "creator.apiUrl") return config.creator?.apiUrl;
   if (key === "creator.projectId") return config.creator?.projectId;
-  return config.creator?.channel;
+  if (key === "creator.channel") return config.creator?.channel;
+  if (key === "platform.managementUrl") return config.platform?.managementUrl;
+  if (key === "platform.oauthIssuer") return config.platform?.oauthIssuer;
+  return config.platform?.oauthClientId;
 }
 
 export async function setConfigValue(
@@ -142,8 +214,14 @@ export async function setConfigValue(
     config.creator = { ...config.creator, apiUrl: value };
   } else if (key === "creator.projectId") {
     config.creator = { ...config.creator, projectId: value };
-  } else {
+  } else if (key === "creator.channel") {
     config.creator = { ...config.creator, channel: value };
+  } else if (key === "platform.managementUrl") {
+    config.platform = { ...config.platform, managementUrl: value };
+  } else if (key === "platform.oauthIssuer") {
+    config.platform = { ...config.platform, oauthIssuer: value };
+  } else {
+    config.platform = { ...config.platform, oauthClientId: value };
   }
   await writeStoreJson(CONFIG_FILE, config);
   return config;
@@ -157,11 +235,23 @@ export async function unsetConfigValue(key: ConfigKey): Promise<SummerConfig> {
     delete config.creator.projectId;
   }
   if (key === "creator.channel" && config.creator) delete config.creator.channel;
+  if (key === "platform.managementUrl" && config.platform) {
+    delete config.platform.managementUrl;
+  }
+  if (key === "platform.oauthIssuer" && config.platform) {
+    delete config.platform.oauthIssuer;
+  }
+  if (key === "platform.oauthClientId" && config.platform) {
+    delete config.platform.oauthClientId;
+  }
   if (config.gateway && Object.keys(config.gateway).length === 0) {
     delete config.gateway;
   }
   if (config.creator && Object.keys(config.creator).length === 0) {
     delete config.creator;
+  }
+  if (config.platform && Object.keys(config.platform).length === 0) {
+    delete config.platform;
   }
   await writeStoreJson(CONFIG_FILE, config);
   return config;
@@ -181,4 +271,31 @@ export async function getGatewayUrl(): Promise<string> {
 export async function getCreatorApiUrl(): Promise<string> {
   const config = await readSummerConfig();
   return config.creator?.apiUrl ?? DEFAULT_CREATOR_API_URL;
+}
+
+export async function getManagementUrl(): Promise<string | null> {
+  const environment = process.env.SUMMER_MANAGEMENT_URL?.trim();
+  if (environment) return validateOrigin("SUMMER_MANAGEMENT_URL", environment);
+  const config = await readSummerConfig();
+  return config.platform?.managementUrl
+    ? validateOrigin("platform.managementUrl", config.platform.managementUrl)
+    : null;
+}
+
+export async function getDeveloperOAuthIssuer(): Promise<string> {
+  const environment = process.env.SUMMER_DEVELOPER_OAUTH_ISSUER?.trim();
+  if (environment) return validateIssuer(environment);
+  const config = await readSummerConfig();
+  return config.platform?.oauthIssuer
+    ? validateIssuer(config.platform.oauthIssuer)
+    : DEFAULT_DEVELOPER_OAUTH_ISSUER;
+}
+
+export async function getDeveloperOAuthClientId(): Promise<string | null> {
+  const environment = process.env.SUMMER_DEVELOPER_OAUTH_CLIENT_ID?.trim();
+  if (environment) return validateValue("platform.oauthClientId", environment);
+  const config = await readSummerConfig();
+  return config.platform?.oauthClientId
+    ? validateValue("platform.oauthClientId", config.platform.oauthClientId)
+    : null;
 }

--- a/src/lib/platform-auth.test.ts
+++ b/src/lib/platform-auth.test.ts
@@ -1,0 +1,169 @@
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getManagementToken,
+  platformOAuthCallbackUrl,
+  runPlatformLogin,
+} from "./platform-auth.js";
+import { setSummerDirForTests, writeStoreJson } from "./store.js";
+
+let root = "";
+const originalIssuer = process.env.SUMMER_DEVELOPER_OAUTH_ISSUER;
+const originalClient = process.env.SUMMER_DEVELOPER_OAUTH_CLIENT_ID;
+const originalToken = process.env.SUMMER_MANAGEMENT_TOKEN;
+
+function accessToken(now: number): string {
+  return accessTokenWithWindow(now, now + 3600_000);
+}
+
+function accessTokenWithWindow(issuedAt: number, expiresAt: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: "ES256", typ: "JWT" })).toString(
+    "base64url"
+  );
+  const payload = Buffer.from(
+    JSON.stringify({
+      iss: "https://identity.example/auth/v1",
+      sub: "developer-subject",
+      aud: "authenticated",
+      iat: Math.floor(issuedAt / 1000),
+      exp: Math.floor(expiresAt / 1000),
+    })
+  ).toString("base64url");
+  return `${header}.${payload}.test-signature`;
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "summer-platform-auth-test-"));
+  setSummerDirForTests(join(root, ".summer"));
+  process.env.SUMMER_DEVELOPER_OAUTH_ISSUER =
+    "https://identity.example/auth/v1";
+  process.env.SUMMER_DEVELOPER_OAUTH_CLIENT_ID = "summer-public-cli";
+  delete process.env.SUMMER_MANAGEMENT_TOKEN;
+});
+
+afterEach(async () => {
+  setSummerDirForTests(null);
+  if (originalIssuer === undefined) delete process.env.SUMMER_DEVELOPER_OAUTH_ISSUER;
+  else process.env.SUMMER_DEVELOPER_OAUTH_ISSUER = originalIssuer;
+  if (originalClient === undefined) delete process.env.SUMMER_DEVELOPER_OAUTH_CLIENT_ID;
+  else process.env.SUMMER_DEVELOPER_OAUTH_CLIENT_ID = originalClient;
+  if (originalToken === undefined) delete process.env.SUMMER_MANAGEMENT_TOKEN;
+  else process.env.SUMMER_MANAGEMENT_TOKEN = originalToken;
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("developer platform OAuth", () => {
+  it("uses public-client authorization code PKCE and stores the Supabase access token separately", async () => {
+    const now = Date.parse("2026-08-25T10:00:00Z");
+    const token = accessToken(now);
+    const authorize = vi.fn(async (url: string, state: string) => {
+      const parsed = new URL(url);
+      expect(parsed.searchParams.get("response_type")).toBe("code");
+      expect(parsed.searchParams.get("client_id")).toBe("summer-public-cli");
+      expect(parsed.searchParams.get("redirect_uri")).toBe(platformOAuthCallbackUrl);
+      expect(parsed.searchParams.get("code_challenge_method")).toBe("S256");
+      expect(parsed.searchParams.get("code_challenge")).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      expect(parsed.searchParams.get("state")).toBe(state);
+      return "authorization-code";
+    });
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/.well-known/openid-configuration")) {
+        return Response.json({
+          issuer: "https://identity.example/auth/v1",
+          authorization_endpoint: "https://identity.example/auth/v1/oauth/authorize",
+          token_endpoint: "https://identity.example/auth/v1/oauth/token",
+          code_challenge_methods_supported: ["S256"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+        });
+      }
+      if (url.endsWith("/oauth/token")) {
+        const form = new URLSearchParams(String(init?.body));
+        expect(form.get("grant_type")).toBe("authorization_code");
+        expect(form.get("client_id")).toBe("summer-public-cli");
+        expect(form.get("code")).toBe("authorization-code");
+        expect(form.get("code_verifier")).toHaveLength(64);
+        expect(form.get("redirect_uri")).toBe(platformOAuthCallbackUrl);
+        return Response.json({
+          access_token: token,
+          refresh_token: "refresh-secret",
+          token_type: "bearer",
+          expires_in: 3600,
+        });
+      }
+      throw new Error(`Unexpected request ${url}`);
+    });
+
+    await runPlatformLogin({
+      fetch: fetchMock as typeof fetch,
+      authorize,
+      randomBytes: (size) => Buffer.alloc(size, 7),
+      now: () => now,
+      log: () => undefined,
+    });
+
+    expect(authorize).toHaveBeenCalledOnce();
+    expect(await getManagementToken({ now: () => now })).toBe(token);
+    const sessionPath = join(root, ".summer", "platform-session.json");
+    const raw = await readFile(sessionPath, "utf8");
+    expect(raw).toContain("refresh-secret");
+    expect(raw).not.toContain("auth-token");
+    if (process.platform !== "win32") {
+      expect((await stat(sessionPath)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("keeps the environment-token seam explicit for local and staging canaries", async () => {
+    process.env.SUMMER_MANAGEMENT_TOKEN = "fixture-management-token";
+    expect(await getManagementToken()).toBe("fixture-management-token");
+  });
+
+  it("refreshes a nearly expired developer session without changing credential audiences", async () => {
+    const now = Date.parse("2026-08-25T10:00:00Z");
+    const oldToken = accessTokenWithWindow(now - 3500_000, now + 50_000);
+    const newToken = accessToken(now);
+    await writeStoreJson("platform-session.json", {
+      schemaVersion: 1,
+      issuer: "https://identity.example/auth/v1",
+      clientId: "summer-public-cli",
+      accessToken: oldToken,
+      refreshToken: "rotating-refresh-secret",
+      expiresAt: new Date(now + 50_000).toISOString(),
+    });
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/.well-known/openid-configuration")) {
+        return Response.json({
+          issuer: "https://identity.example/auth/v1",
+          authorization_endpoint: "https://identity.example/auth/v1/oauth/authorize",
+          token_endpoint: "https://identity.example/auth/v1/oauth/token",
+          code_challenge_methods_supported: ["S256"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+        });
+      }
+      if (url.endsWith("/oauth/token")) {
+        const form = new URLSearchParams(String(init?.body));
+        expect(form.get("grant_type")).toBe("refresh_token");
+        expect(form.get("refresh_token")).toBe("rotating-refresh-secret");
+        return Response.json({
+          access_token: newToken,
+          refresh_token: "next-refresh-secret",
+          token_type: "bearer",
+        });
+      }
+      throw new Error(`Unexpected request ${url}`);
+    });
+
+    expect(
+      await getManagementToken({
+        fetch: fetchMock as typeof fetch,
+        now: () => now,
+      })
+    ).toBe(newToken);
+    expect(
+      await readFile(join(root, ".summer", "platform-session.json"), "utf8")
+    ).toContain("next-refresh-secret");
+  });
+});

--- a/src/lib/platform-auth.ts
+++ b/src/lib/platform-auth.ts
@@ -1,0 +1,359 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import { createServer } from "node:http";
+import open from "open";
+import {
+  getDeveloperOAuthClientId,
+  getDeveloperOAuthIssuer,
+} from "./config.js";
+import {
+  readStoreJson,
+  removeStoreFile,
+  writeStoreJson,
+} from "./store.js";
+
+const PLATFORM_SESSION_FILE = "platform-session.json";
+const CALLBACK_URL = "http://127.0.0.1:1455/oauth/callback";
+const LOGIN_TIMEOUT_MS = 15 * 60_000;
+
+interface OAuthDiscovery {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  code_challenge_methods_supported?: string[];
+  grant_types_supported?: string[];
+}
+
+interface OAuthTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  token_type?: string;
+}
+
+export interface PlatformSession {
+  schemaVersion: 1;
+  issuer: string;
+  clientId: string;
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt: string;
+}
+
+export interface PlatformLoginDependencies {
+  fetch: typeof fetch;
+  authorize: (url: string, state: string) => Promise<string>;
+  randomBytes: (size: number) => Buffer;
+  now: () => number;
+  log: (message: string) => void;
+}
+
+async function browserAuthorization(url: string, expectedState: string): Promise<string> {
+  const callback = new URL(CALLBACK_URL);
+  let timer: NodeJS.Timeout | undefined;
+  return new Promise<string>((resolvePromise, reject) => {
+    let settled = false;
+    const finish = (error?: Error, code?: string) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      server.close(() => {
+        if (error) reject(error);
+        else resolvePromise(code!);
+      });
+    };
+    const server = createServer((request, response) => {
+      const requestUrl = new URL(request.url ?? "/", CALLBACK_URL);
+      if (request.method !== "GET" || requestUrl.pathname !== callback.pathname) {
+        response.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+        response.end("Not found");
+        return;
+      }
+      const state = requestUrl.searchParams.get("state") ?? "";
+      const stateMatches =
+        state.length === expectedState.length &&
+        timingSafeEqual(Buffer.from(state), Buffer.from(expectedState));
+      const error = requestUrl.searchParams.get("error");
+      const code = requestUrl.searchParams.get("code");
+      if (!stateMatches || error || !code) {
+        response.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
+        response.end("Summer sign-in was rejected. You can close this tab.");
+        finish(
+          new Error(
+            error
+              ? `Developer sign-in was rejected: ${error}.`
+              : "Developer sign-in returned an invalid callback."
+          )
+        );
+        return;
+      }
+      response.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" });
+      response.end("Signed in to Summer. You can close this tab.");
+      finish(undefined, code);
+    });
+    server.once("error", (error) => finish(error));
+    server.listen(Number(callback.port), callback.hostname, async () => {
+      try {
+        await open(url);
+      } catch {
+        // The URL is printed by the command, so a headless user can open it.
+      }
+    });
+    timer = setTimeout(
+      () => finish(new Error('Developer sign-in timed out. Run "summer login --platform" again.')),
+      LOGIN_TIMEOUT_MS
+    );
+    timer.unref();
+  });
+}
+
+const defaultDependencies: PlatformLoginDependencies = {
+  fetch,
+  authorize: browserAuthorization,
+  randomBytes,
+  now: Date.now,
+  log: console.log,
+};
+
+function endpoint(value: string, expectedOrigin: string, name: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`OAuth discovery returned an invalid ${name}.`);
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.origin !== expectedOrigin ||
+    parsed.username ||
+    parsed.password ||
+    parsed.hash
+  ) {
+    throw new Error(`OAuth discovery returned an unsafe ${name}.`);
+  }
+  return parsed.toString();
+}
+
+async function discover(
+  fetchImplementation: typeof fetch,
+  issuer: string
+): Promise<OAuthDiscovery> {
+  const response = await fetchImplementation(
+    `${issuer}/.well-known/openid-configuration`,
+    { redirect: "error", signal: AbortSignal.timeout(10_000) }
+  );
+  if (!response.ok) {
+    throw new Error(`Developer OAuth discovery failed (${response.status}).`);
+  }
+  const document = (await response.json()) as Partial<OAuthDiscovery>;
+  if (
+    document.issuer !== issuer ||
+    typeof document.authorization_endpoint !== "string" ||
+    typeof document.token_endpoint !== "string" ||
+    !document.code_challenge_methods_supported?.includes("S256") ||
+    !document.grant_types_supported?.includes("authorization_code") ||
+    !document.grant_types_supported?.includes("refresh_token")
+  ) {
+    throw new Error("Developer OAuth discovery does not support the required PKCE and refresh contract.");
+  }
+  const origin = new URL(issuer).origin;
+  return {
+    ...document,
+    issuer,
+    authorization_endpoint: endpoint(
+      document.authorization_endpoint,
+      origin,
+      "authorization endpoint"
+    ),
+    token_endpoint: endpoint(document.token_endpoint, origin, "token endpoint"),
+  };
+}
+
+function decodePart(value: string): Record<string, unknown> {
+  try {
+    return JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    throw new Error("The developer identity provider returned a malformed access token.");
+  }
+}
+
+function validateAccessToken(tokenValue: string, issuer: string, now: number): number {
+  const parts = tokenValue.split(".");
+  if (parts.length !== 3 || tokenValue.length > 16 * 1024) {
+    throw new Error("The developer identity provider returned a malformed access token.");
+  }
+  const header = decodePart(parts[0]);
+  const claims = decodePart(parts[1]);
+  const audiences =
+    typeof claims.aud === "string"
+      ? [claims.aud]
+      : Array.isArray(claims.aud)
+        ? claims.aud
+        : [];
+  const expiresAt = typeof claims.exp === "number" ? claims.exp * 1000 : 0;
+  const issuedAt = typeof claims.iat === "number" ? claims.iat * 1000 : 0;
+  if (
+    header.alg !== "ES256" ||
+    claims.iss !== issuer ||
+    audiences.length !== 1 ||
+    audiences[0] !== "authenticated" ||
+    typeof claims.sub !== "string" ||
+    claims.sub.length === 0 ||
+    claims.sub.length > 512 ||
+    !issuedAt ||
+    !expiresAt ||
+    issuedAt > now + 30_000 ||
+    expiresAt <= now ||
+    expiresAt - issuedAt > 60 * 60_000
+  ) {
+    throw new Error("The developer access token does not match the Summer management credential contract.");
+  }
+  return expiresAt;
+}
+
+async function tokenRequest(
+  deps: PlatformLoginDependencies,
+  discovery: OAuthDiscovery,
+  values: Record<string, string>
+): Promise<OAuthTokenResponse> {
+  const response = await deps.fetch(discovery.token_endpoint, {
+    method: "POST",
+    redirect: "error",
+    signal: AbortSignal.timeout(15_000),
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams(values),
+  });
+  if (!response.ok) {
+    throw new Error(`Developer OAuth token exchange failed (${response.status}).`);
+  }
+  const result = (await response.json()) as Partial<OAuthTokenResponse>;
+  if (
+    typeof result.access_token !== "string" ||
+    result.access_token.length === 0 ||
+    (result.token_type && result.token_type.toLowerCase() !== "bearer")
+  ) {
+    throw new Error("Developer OAuth returned an incomplete token response.");
+  }
+  return result as OAuthTokenResponse;
+}
+
+export async function runPlatformLogin(
+  overrides: Partial<PlatformLoginDependencies> = {}
+): Promise<void> {
+  const deps = { ...defaultDependencies, ...overrides };
+  const issuer = await getDeveloperOAuthIssuer();
+  const clientId = await getDeveloperOAuthClientId();
+  if (!clientId) {
+    throw new Error(
+      'No Summer developer OAuth client is configured. Set the registered public client with "summer config set platform.oauthClientId <client-id>" and retry.'
+    );
+  }
+  const discovery = await discover(deps.fetch, issuer);
+  const verifier = deps.randomBytes(48).toString("base64url");
+  const state = deps.randomBytes(32).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  const authorization = new URL(discovery.authorization_endpoint);
+  authorization.searchParams.set("response_type", "code");
+  authorization.searchParams.set("client_id", clientId);
+  authorization.searchParams.set("redirect_uri", CALLBACK_URL);
+  authorization.searchParams.set("scope", "openid email profile");
+  authorization.searchParams.set("state", state);
+  authorization.searchParams.set("code_challenge", challenge);
+  authorization.searchParams.set("code_challenge_method", "S256");
+  deps.log(`Sign in at: ${authorization.toString()}`);
+  const code = await deps.authorize(authorization.toString(), state);
+  const tokenResult = await tokenRequest(deps, discovery, {
+    grant_type: "authorization_code",
+    client_id: clientId,
+    code,
+    code_verifier: verifier,
+    redirect_uri: CALLBACK_URL,
+  });
+  const expiresAt = validateAccessToken(tokenResult.access_token, issuer, deps.now());
+  await writeStoreJson(PLATFORM_SESSION_FILE, {
+    schemaVersion: 1,
+    issuer,
+    clientId,
+    accessToken: tokenResult.access_token,
+    ...(tokenResult.refresh_token ? { refreshToken: tokenResult.refresh_token } : {}),
+    expiresAt: new Date(expiresAt).toISOString(),
+  } satisfies PlatformSession);
+  deps.log("Developer platform sign-in complete.");
+}
+
+async function refreshSession(
+  session: PlatformSession,
+  overrides: Partial<PlatformLoginDependencies> = {}
+): Promise<PlatformSession> {
+  if (!session.refreshToken) {
+    throw new Error('Developer sign-in expired. Run "summer login --platform" again.');
+  }
+  const deps = { ...defaultDependencies, ...overrides };
+  const discovery = await discover(deps.fetch, session.issuer);
+  const result = await tokenRequest(deps, discovery, {
+    grant_type: "refresh_token",
+    client_id: session.clientId,
+    refresh_token: session.refreshToken,
+  });
+  const expiresAt = validateAccessToken(result.access_token, session.issuer, deps.now());
+  const next: PlatformSession = {
+    ...session,
+    accessToken: result.access_token,
+    refreshToken: result.refresh_token ?? session.refreshToken,
+    expiresAt: new Date(expiresAt).toISOString(),
+  };
+  await writeStoreJson(PLATFORM_SESSION_FILE, next);
+  return next;
+}
+
+export async function getManagementToken(
+  overrides: Partial<PlatformLoginDependencies> = {}
+): Promise<string> {
+  const environment = process.env.SUMMER_MANAGEMENT_TOKEN?.trim();
+  if (environment) return environment;
+  const session = await readStoreJson<PlatformSession>(PLATFORM_SESSION_FILE);
+  if (
+    !session ||
+    session.schemaVersion !== 1 ||
+    typeof session.issuer !== "string" ||
+    typeof session.clientId !== "string" ||
+    typeof session.accessToken !== "string"
+  ) {
+    throw new Error('No developer platform session exists. Run "summer login --platform" first.');
+  }
+  const deps = { ...defaultDependencies, ...overrides };
+  const expectedIssuer = await getDeveloperOAuthIssuer();
+  const expectedClientId = await getDeveloperOAuthClientId();
+  if (
+    session.issuer !== expectedIssuer ||
+    (expectedClientId !== null && session.clientId !== expectedClientId)
+  ) {
+    throw new Error('The stored developer session does not match current configuration. Run "summer login --platform --force".');
+  }
+  try {
+    const expiresAt = validateAccessToken(
+      session.accessToken,
+      session.issuer,
+      deps.now()
+    );
+    if (expiresAt - deps.now() > 60_000) return session.accessToken;
+  } catch {
+    // A refresh below is the only recovery for an expired or malformed token.
+  }
+  return (await refreshSession(session, deps)).accessToken;
+}
+
+export async function hasPlatformSession(): Promise<boolean> {
+  return (await readStoreJson<PlatformSession>(PLATFORM_SESSION_FILE)) !== null;
+}
+
+export async function clearPlatformSession(): Promise<boolean> {
+  return removeStoreFile(PLATFORM_SESSION_FILE);
+}
+
+export const platformOAuthCallbackUrl = CALLBACK_URL;

--- a/src/lib/store-auth-config.test.ts
+++ b/src/lib/store-auth-config.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./auth.js";
 import {
   getConfigValue,
+  getManagementUrl,
   getGatewayUrl,
   readSummerConfig,
   setConfigValue,
@@ -147,6 +148,8 @@ describe("shared Summer config", () => {
     await setConfigValue("creator.channel", "preview");
     await setConfigValue("creator.apiUrl", "http://localhost:3000");
     await setConfigValue("gateway.url", "https://gateway.example/");
+    await setConfigValue("platform.managementUrl", "https://management.example/");
+    await setConfigValue("platform.oauthClientId", "summer-public-cli");
 
     const config = await readSummerConfig();
     expect(getConfigValue(config, "creator.projectId")).toBe("project-123");
@@ -155,6 +158,10 @@ describe("shared Summer config", () => {
       "http://localhost:3000"
     );
     expect(await getGatewayUrl()).toBe("https://gateway.example");
+    expect(await getManagementUrl()).toBe("https://management.example");
+    expect(getConfigValue(config, "platform.oauthClientId")).toBe(
+      "summer-public-cli"
+    );
 
     await unsetConfigValue("creator.channel");
     expect(


### PR DESCRIPTION
## Outcome

Adds a supported, resumable creator command for frequent hosted server-Build publication:

```bash
summer login --platform
summer build publish . --version 1.0.0
```

The command deterministically packages the declared project, creates a platform BuildPublication, uploads through its bounded direct-upload grant, seals the source as a draft, explicitly publishes that draft, and observes platform workers until the immutable Build is ready. `--no-wait` returns once the sealed draft is published and queued.

It never builds with a local trusted toolchain, pushes a server image, creates a Release, or deploys anything. The existing Summercraft `.pck` command `summer publish` is unchanged.

## Root cause

Hosted server builds had a durable worker pipeline but no supported customer client. Creators had to reproduce internal scripts, policy fields, hashing, upload headers, idempotency, and polling by hand. That is interface-design friction in a workflow customers will use frequently.

## What changed

- Adds tracked `summer.build.json` for stable creator intent; route Game identity and active Engine/SDK policy remain server-owned.
- Creates deterministic ZIPs with stable ordering/metadata and fails before intake on symlinks, excluded required files, unstable files, or oversized archives.
- Sends the management bearer only to the management origin; the object host receives only the exact platform-signed upload headers.
- Uses stable idempotency keys and resumes at durable uploading, draft, pending, worker, or terminal boundaries.
- Re-resolves the management session for every exchange so long uploads/builds can refresh an expiring token.
- Adds separate `summer login --platform` OAuth authorization-code + PKCE login and mode-0600 access/refresh-token storage. Core Summer auth and Summercraft creator auth stay separate.
- Requires an explicitly configured management origin; no made-up production hostname is embedded.

## Coordinated platform dependency

Requires SummerEngine/summer-platform#101. Roll out its database migration first, then complete the management-API rollout, then release this npm client. The CLI depends on the explicit `:publish` endpoint and must not be released against an old or mixed management-API fleet.

A Supabase public OAuth client must also be registered for callback `http://127.0.0.1:1455/oauth/callback`, and its non-secret client ID must be configured as `platform.oauthClientId`. The current management developer-token contract uses the fixed `authenticated` audience and does not require an `azp` allowlist. This PR does not alter Supabase or PublicSummerEngine.

## Risk

**Medium.** The feature is a new opt-in command and separate credential store, so existing CLI commands and native Engine users are unaffected. Risk is concentrated in archive byte stability, token lifetime, upload-boundary leakage, and lifecycle resumption. Those areas have focused end-to-end mocked coverage. `yazl` is the only new runtime dependency.

No native Engine change, native build, or coordinated web application change is required. Users do not have this command until this PR is merged and a new npm package version is published.

## Verification

- `npm run build`
- `npm test`: 49 files, 442 tests passed
- focused platform auth/config/BuildPublication tests: 15 passed
- `npm pack --dry-run --json`: package contains the command, publisher, and auth artifacts
- rendered `summer build publish --help`
- `git diff --check`

