### PR TITLE
feat(mcp): expose removeBackground on summer_generate_image

### DIFF
--- a/src/mcp/tools/generate-tools.test.ts
+++ b/src/mcp/tools/generate-tools.test.ts
@@ -378,3 +378,51 @@ describe("registerGenerateTools — provider validation errors", () => {
     expect((init.headers as any)["X-Summer-Client-Version"]).toMatch(/\d+\.\d+\.\d+/);
   });
 });
+
+describe("registerGenerateTools — summer_generate_image removeBackground", () => {
+  it("exposes the flag in the schema and warns about fake checkerboards", () => {
+    const { server, tools } = createFakeServer();
+    registerGenerateTools(server as any);
+
+    const image = getTool(tools, "summer_generate_image");
+    expect(image.schema.removeBackground).toBeDefined();
+    expect(image.description).toContain("removeBackground: true");
+    expect(image.description).toContain("checkerboard");
+  });
+
+  it("forwards removeBackground: true in the request body", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ success: true, asset: { id: "a1" } }),
+    }));
+    globalThis.fetch = fetchMock as any;
+
+    const { server, tools } = createFakeServer();
+    registerGenerateTools(server as any);
+    const image = getTool(tools, "summer_generate_image");
+
+    await image.handler({ prompt: "hooded figure sprite", removeBackground: true });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string).removeBackground).toBe(true);
+  });
+
+  it("omits the key entirely when the flag is not passed", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ success: true, asset: { id: "a2" } }),
+    }));
+    globalThis.fetch = fetchMock as any;
+
+    const { server, tools } = createFakeServer();
+    registerGenerateTools(server as any);
+    const image = getTool(tools, "summer_generate_image");
+
+    await image.handler({ prompt: "forest floor texture" });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).not.toHaveProperty("removeBackground");
+  });
+});

--- a/src/mcp/tools/generate-tools.ts
+++ b/src/mcp/tools/generate-tools.ts
@@ -342,6 +342,13 @@ Two modes:
 
 Style presets: "realistic" (default), "cartoon", "anime", "none"
 
+Transparent backgrounds: image models CANNOT output an alpha channel. If the
+prompt asks for a "transparent background", the model paints a fake grey
+checkerboard into the pixels instead — unusable as a sprite. For sprites,
+icons, and isolated objects set removeBackground: true and keep transparency
+wording OUT of the prompt: Summer strips the background server-side and
+returns a real alpha PNG.
+
 The 'options' object is passed directly to the AI provider for full control.
 
 Returns the asset with fileUrl (hosted) and localPath (temp file on disk).
@@ -363,17 +370,24 @@ Requires authentication: run 'npx summer-engine login' first.`,
         .string()
         .optional()
         .describe("Source image URL for img2img / edit mode. The prompt describes how to transform this image."),
+      removeBackground: z
+        .boolean()
+        .optional()
+        .describe(
+          "Set true for sprites, icons, or isolated objects that need a real transparent background (alpha PNG). Do NOT ask for transparency in the prompt — models bake a fake checkerboard into the pixels instead."
+        ),
       options: z
         .record(z.any())
         .optional()
         .describe("Provider-specific params (guidance_scale, seed, image_size, negative_prompt, etc.)"),
     },
-    async ({ prompt, model, style, referenceImageUrl, options }) => {
+    async ({ prompt, model, style, referenceImageUrl, removeBackground, options }) => {
       const result = await mcpGenerate("/api/mcp/generate/image", {
         prompt,
         model,
         style,
         referenceImageUrl,
+        removeBackground,
         options,
       });
 


### PR DESCRIPTION
## What

Adds a first-class `removeBackground: boolean` parameter to the `summer_generate_image` MCP tool, forwards it in the POST body to `/api/mcp/generate/image`, and documents the transparency trap in the tool description.

## Why

Image models cannot emit an alpha channel. When a client agent writes "transparent background" into the prompt, the model bakes a fake grey checkerboard into the RGB pixels — no alpha at all, unusable as a game sprite. The server has supported real background removal all along (`removeBackground` in the request body → Bria removal → true alpha PNG, billed as `background_removal`), but the MCP surface never exposed or documented it, so agents predictably fell into the prompt trap. This cost us a paying user on day one.

Linear: [SUM-344](https://linear.app/summerengine/issue/SUM-344/mcp-generate-image-transparent-background-prompts-return-a-baked)

## Changes

- `src/mcp/tools/generate-tools.ts`: new `removeBackground` schema param + body passthrough + description section warning to keep transparency wording out of prompts.
- `src/mcp/tools/generate-tools.test.ts`: 3 new tests — schema/description exposure, flag forwarded when true, key omitted when unset.

No server changes required; the web route honors the flag as-is.

## Verification

- `npm test`: 47 files, 435 tests pass (3 new).
- `npm run build`: clean tsc build.
- Post-merge: needs a version bump + npm publish for deployed CLIs to pick it up; a live smoke (`removeBackground: true` → `hasAlpha: yes`) after publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)