### PR TITLE
Sync public source with summer-engine 2.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to summer-engine will be documented here. Following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/).
 
+## [2.8.2] — 2026-09-01 — "Windows setup works out of the box"
+
+### Fixed
+- Windows: generated MCP configs now launch the server via `cmd.exe /c npx ...` instead of `command: "npx"`. `npx` is a `.cmd`/`.ps1` shim on Windows and Node's `spawn()` does no PATHEXT resolution, so agent hosts that spawn the command directly (Claude Code, Kimi Code, Cursor, ...) failed with `spawn npx ENOENT` even though npx worked in a terminal. Reported by Imitater967 — thank you. Re-run `npx -y summer-engine@latest setup <agent> --yes --force` on Windows to rewrite the config; docs for manual configs carry the same note.
+- Six shipped skills (`host-authoritative-state`, `setup-multiplayer`, `scene-composition`, `make-game`, `ui-basics`, `mcpupdate`) had unquoted colons in their YAML frontmatter descriptions — strict YAML parsers rejected the frontmatter and skipped the skill entirely. Descriptions are now quoted; all shipped skill frontmatter is YAML-validated.
+
 ## [2.8.1] — 2026-08-18 — "Scene mutations work again on engine 0.5.60+"
 
 ### Added

--- a/docs/CLAUDE_CODE.md
+++ b/docs/CLAUDE_CODE.md
@@ -52,6 +52,8 @@ Add Summer as an MCP server using your Claude Code MCP configuration:
 }
 ```
 
+> **Windows:** use `"command": "cmd.exe", "args": ["/c", "npx", "-y", "summer-engine@latest", "mcp"]` instead — `npx` is a `.cmd` shim on Windows and hosts that spawn it directly fail with ENOENT. `summer setup` writes the right form automatically.
+
 Run the engine before asking Claude Code to modify scenes:
 
 ```bash

--- a/docs/CURSOR.md
+++ b/docs/CURSOR.md
@@ -53,6 +53,8 @@ Add Summer to `.cursor/mcp.json`:
 }
 ```
 
+> **Windows:** use `"command": "cmd.exe", "args": ["/c", "npx", "-y", "summer-engine@latest", "mcp"]` instead — `npx` is a `.cmd` shim on Windows and hosts that spawn it directly fail with ENOENT. `summer setup` writes the right form automatically.
+
 Keep the engine open on the project:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "summer-engine",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "summer-engine",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "summer-engine",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "Local Summer CLI and MCP server for Summer Engine. Install and run the engine, connect Claude Code, Cursor, Codex, Gemini, and other agents, and build real games with bundled skills, hooks, and plugins.",
   "keywords": [
     "summer-engine",

--- a/skills/multiplayer-and-networking/host-authoritative-state/SKILL.md
+++ b/skills/multiplayer-and-networking/host-authoritative-state/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: host-authoritative-state
-description: Use when designing the state layer of a multiplayer Summer game: deciding what the host owns, how clients request changes, and how the host validates and broadcasts. Pairs with `/peer-to-peer-multiplayer`. Trigger on "host authority", "authoritative state", "state ownership", "MP cheating", "client validation", "RPC patterns".
+description: "Use when designing the state layer of a multiplayer Summer game: deciding what the host owns, how clients request changes, and how the host validates and broadcasts. Pairs with `/peer-to-peer-multiplayer`. Trigger on \"host authority\", \"authoritative state\", \"state ownership\", \"MP cheating\", \"client validation\", \"RPC patterns\"."
 license: MIT
 compatibility: [Cursor, Claude Code, Windsurf, Codex]
 category: multiplayer-and-networking

--- a/skills/multiplayer-and-networking/setup-multiplayer/SKILL.md
+++ b/skills/multiplayer-and-networking/setup-multiplayer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-multiplayer
-description: Use when the user wants to add multiplayer to an existing Summer game: co-op LAN, co-op online, competitive PvP, or a lobby. Start with Summer Engine's high-level MultiplayerAPI plus MultiplayerSpawner and MultiplayerSynchronizer; use custom networking only with a justified reason. Walks peer authority, RPC patterns, replication, and irreversible architecture decisions. It does not claim that managed matchmaking or hosting is live. Trigger on "multiplayer", "co-op", "PvP", "online", "netcode", "rollback", "MultiplayerAPI", "host migration", "matchmaking".
+description: "Use when the user wants to add multiplayer to an existing Summer game: co-op LAN, co-op online, competitive PvP, or a lobby. Start with Summer Engine's high-level MultiplayerAPI plus MultiplayerSpawner and MultiplayerSynchronizer; use custom networking only with a justified reason. Walks peer authority, RPC patterns, replication, and irreversible architecture decisions. It does not claim that managed matchmaking or hosting is live. Trigger on \"multiplayer\", \"co-op\", \"PvP\", \"online\", \"netcode\", \"rollback\", \"MultiplayerAPI\", \"host migration\", \"matchmaking\"."
 license: MIT
 compatibility: [Cursor, Claude Code, Windsurf, Codex]
 category: multiplayer-and-networking

--- a/skills/scene-and-project/make-game/SKILL.md
+++ b/skills/scene-and-project/make-game/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: make-game
-description: Use when the user says "make me a game", "build me a game", "I want to make a [genre] game", "let's build something" — the orchestration spine that runs the full game-dev pipeline: brainstorm → plan → scaffold → build core mechanics → art direction → audio → polish/VFX → verify → ship. Delegates to specialist skills with explicit checkpoints between phases. Trigger on "make a game", "build me a game", "create a new game", "make me a game", "let's build a game", "I want to build [game shape]".
+description: "Use when the user says \"make me a game\", \"build me a game\", \"I want to make a [genre] game\", \"let's build something\" \u2014 the orchestration spine that runs the full game-dev pipeline: brainstorm \u2192 plan \u2192 scaffold \u2192 build core mechanics \u2192 art direction \u2192 audio \u2192 polish/VFX \u2192 verify \u2192 ship. Delegates to specialist skills with explicit checkpoints between phases. Trigger on \"make a game\", \"build me a game\", \"create a new game\", \"make me a game\", \"let's build a game\", \"I want to build [game shape]\"."
 license: MIT
 compatibility: [Cursor, Claude Code, Codex, Windsurf, Gemini, OpenCode]
 category: scene-and-project

--- a/skills/scene-and-project/scene-composition/SKILL.md
+++ b/skills/scene-and-project/scene-composition/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scene-composition
-description: Use when building or organizing Summer Engine scenes: node hierarchy conventions, when to extract sub-scenes, reusable prefab patterns, and instance-versus-add-node decisions. Trigger on "scene", "sub-scene", "instance", "prefab", "node hierarchy", "scene structure", "PackedScene".
+description: "Use when building or organizing Summer Engine scenes: node hierarchy conventions, when to extract sub-scenes, reusable prefab patterns, and instance-versus-add-node decisions. Trigger on \"scene\", \"sub-scene\", \"instance\", \"prefab\", \"node hierarchy\", \"scene structure\", \"PackedScene\"."
 license: MIT
 compatibility: [Cursor, Claude Code, Windsurf, Codex]
 category: scene-and-project

--- a/skills/ui-and-ux/ui-basics/SKILL.md
+++ b/skills/ui-and-ux/ui-basics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-basics
-description: Use when building Summer Engine UI: HUDs, main menus, pause menus, health bars, progress bars, dialogue boxes, or any Control-node tree. Covers anchors, containers (VBox/HBox/Margin), responsive layout, and theme versus inline styling. Trigger on "UI", "HUD", "menu", "health bar", "Control", "anchors", "VBoxContainer", "main menu", "pause menu".
+description: "Use when building Summer Engine UI: HUDs, main menus, pause menus, health bars, progress bars, dialogue boxes, or any Control-node tree. Covers anchors, containers (VBox/HBox/Margin), responsive layout, and theme versus inline styling. Trigger on \"UI\", \"HUD\", \"menu\", \"health bar\", \"Control\", \"anchors\", \"VBoxContainer\", \"main menu\", \"pause menu\"."
 license: MIT
 compatibility: [Cursor, Claude Code, Windsurf, Codex]
 category: ui-and-ux

--- a/skills/workflow/mcpupdate/SKILL.md
+++ b/skills/workflow/mcpupdate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcpupdate
-description: Use when improving or maintaining the Summer Engine CLI, its MCP tools (summer_* / "ops"), or its prompt-engineering skills based on a real working session. Examples: the user types /mcpupdate, says "mcpskillify this", "log this as a skill/example", "this <feature> feels great, capture it", or notes that an agent went down a bad path with the Summer tools/skills and the prompts should be fixed. Works from ANY chat, not just inside the summer-cli repo.
+description: "Use when improving or maintaining the Summer Engine CLI, its MCP tools (summer_* / \"ops\"), or its prompt-engineering skills based on a real working session. Examples: the user types /mcpupdate, says \"mcpskillify this\", \"log this as a skill/example\", \"this <feature> feels great, capture it\", or notes that an agent went down a bad path with the Summer tools/skills and the prompts should be fixed. Works from ANY chat, not just inside the summer-cli repo."
 ---
 
 # mcpupdate: turn a session into improvements to the Summer CLI / MCP / skills

--- a/src/lib/agent-config.test.ts
+++ b/src/lib/agent-config.test.ts
@@ -34,6 +34,24 @@ describe("createSummerMcpServerConfig", () => {
     expect(server.command).toBe("npx");
     expect(server.args).toEqual(NPX_ARGS);
   });
+
+  it("routes npx through cmd.exe on Windows (spawn does no PATHEXT resolution)", () => {
+    const server = createSummerMcpServerConfig(false, "win32");
+    expect(server.command).toBe("cmd.exe");
+    expect(server.args).toEqual(["/c", "npx", ...NPX_ARGS]);
+  });
+
+  it("keeps plain npx on non-Windows platforms", () => {
+    for (const platform of ["darwin", "linux"] as const) {
+      const server = createSummerMcpServerConfig(false, platform);
+      expect(server.command).toBe("npx");
+      expect(server.args).toEqual(NPX_ARGS);
+    }
+  });
+
+  it("keeps node (a real executable) for localDev on every platform", () => {
+    expect(createSummerMcpServerConfig(true, "win32").command).toBe("node");
+  });
 });
 
 describe("configureAgentMcp", () => {

--- a/src/lib/agent-config.ts
+++ b/src/lib/agent-config.ts
@@ -149,11 +149,26 @@ export async function configureAgentMcp(
   };
 }
 
-export function createSummerMcpServerConfig(localDev: boolean): StdioMcpServerConfig {
+export function createSummerMcpServerConfig(
+  localDev: boolean,
+  platform: NodeJS.Platform = process.platform
+): StdioMcpServerConfig {
   if (localDev) {
+    // node is a real executable on every platform; spawn("node") resolves fine.
     return {
       command: "node",
       args: [resolveLocalCliPath(), "mcp"],
+    };
+  }
+
+  // On Windows, npx is a .cmd/.ps1 shim, and Node's spawn() does not do PATHEXT
+  // resolution — hosts that spawn("npx") directly (Claude Code, Kimi Code,
+  // Cursor, ...) fail with ENOENT even though npx works in a terminal. Route
+  // through cmd.exe so the shim resolves. (User-reported: Imitater967, 2026-09-01.)
+  if (platform === "win32") {
+    return {
+      command: "cmd.exe",
+      args: ["/c", "npx", "-y", "summer-engine@latest", "mcp"],
     };
   }
 


### PR DESCRIPTION
Windows MCP setup fix (cmd.exe /c npx wrapper for the spawn ENOENT on Windows, reported by a user) + six skills' YAML frontmatter descriptions quoted so strict parsers stop skipping them. Verified here: npm ci, tests, build, publish dry-run at 2.8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)