### PR TITLE
Add a 3D world-building skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -47,6 +47,7 @@
     "./skills/scene-and-project/browse-templates/",
     "./skills/scene-and-project/play/",
     "./skills/scene-and-project/scene-composition/",
+    "./skills/scene-and-project/world-building-3d/",
     "./skills/scene-and-project/summer-cloud/",
     "./skills/scene-and-project/make-game/",
     "./skills/debugging/debug/",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -36,6 +36,7 @@
     "./skills/scene-and-project/browse-templates/",
     "./skills/scene-and-project/play/",
     "./skills/scene-and-project/scene-composition/",
+    "./skills/scene-and-project/world-building-3d/",
     "./skills/scene-and-project/summer-cloud/",
     "./skills/scene-and-project/make-game/",
     "./skills/debugging/debug/",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -38,6 +38,7 @@
     "./skills/scene-and-project/browse-templates/",
     "./skills/scene-and-project/play/",
     "./skills/scene-and-project/scene-composition/",
+    "./skills/scene-and-project/world-building-3d/",
     "./skills/scene-and-project/summer-cloud/",
     "./skills/scene-and-project/make-game/",
     "./skills/debugging/debug/",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ This file is for any AI agent that loads context from `AGENTS.md` (Codex CLI, Fa
 ## Skill priority
 
 - **Process** (`brainstorm-game`, `debug`, `play`) → how to approach.
-- **Discipline** (`gdscript-patterns`, `scene-composition`, `art-direction`) → how to shape it.
+- **Discipline** (`gdscript-patterns`, `scene-composition`, `world-building-3d`, `art-direction`) → how to shape it.
 - **Build** (`fps-controller`, `design-mechanic`, `design-level`, `setup-multiplayer`, `vfx`, `tune-performance`, `export-and-ship`) → produce the artifact.
 
 ## MCP tool palette (project-matched local editor)
@@ -31,6 +31,7 @@ The current MCP registry is grouped into these categories:
 - Diagnostics: `summer_create_debug_report`, `summer_get_script_errors`, `summer_get_diagnostics`, `summer_get_console`, `summer_clear_console`, `summer_get_debugger_errors`, `summer_get_debugger_warnings`.
 - Runtime: `summer_play`, `summer_stop`, `summer_is_running`.
 - Visual: `summer_screenshot` (capture the editor viewport or running game as an image to verify it).
+- Spatial layout: `summer_test_placement`, `summer_snap_to_surface`, `summer_align_distribute_3d`, `summer_frame_camera`, `summer_camera_visibility`, `summer_navigation_probe`.
 - Project: `summer_get_project_context`, `summer_open_main_scene`, `summer_project_setting`, `summer_input_map_bind`, `summer_get_agent_playbook`.
 - Files: `summer_read_file`, `summer_write_file`, `summer_replace_text` (identity-bound; create-only or sha256-guarded writes).
 - Assets: `summer_search_assets`, `summer_list_my_assets`, `summer_get_asset`, `summer_get_asset_download_url`, `summer_import_asset`, `summer_import_asset_by_id`, `summer_import_from_url`, `summer_import_from_url_batch`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -15,7 +15,7 @@ The single most important skill to know is `summer:using-summer` — it explains
 ## Skill priority
 
 1. **Process skills first**: `brainstorm-game`, `debug`, `play`. These determine HOW.
-2. **Discipline skills second**: `gdscript-patterns`, `scene-composition`, `art-direction`, `audio-direction`. These shape content.
+2. **Discipline skills second**: `gdscript-patterns`, `scene-composition`, `world-building-3d`, `art-direction`, `audio-direction`. These shape content.
 3. **Build skills third**: `fps-controller`, `design-mechanic`, `design-level`, `setup-multiplayer`, `vfx`, `tune-performance`, `export-and-ship`.
 
 ## MCP tools (when the project-matched local editor is running)
@@ -27,6 +27,7 @@ The `summer-engine` MCP server exposes a focused tool registry. The most importa
 - **Diagnostics**: `summer_create_debug_report`, `summer_get_script_errors` (cheapest), `summer_get_diagnostics`, `summer_get_console`, `summer_get_debugger_errors`, `summer_get_debugger_warnings`.
 - **Run game**: `summer_play`, `summer_stop`, `summer_is_running`.
 - **Visual**: `summer_screenshot` (capture the viewport or running game as an image you can see).
+- **Spatial layout**: `summer_test_placement`, `summer_snap_to_surface`, `summer_align_distribute_3d`, `summer_frame_camera`, `summer_camera_visibility`, `summer_navigation_probe`.
 - **Project**: `summer_get_project_context`, `summer_open_main_scene`, `summer_project_setting`, `summer_input_map_bind`.
 - **Files**: `summer_read_file`, `summer_write_file`, `summer_replace_text` (identity-bound, create-only or sha256-guarded mutations).
 - **Assets**: `summer_search_assets`, `summer_import_asset`, `summer_import_from_url`, `summer_generate_image`, `summer_generate_3d`, `summer_generate_audio`, `summer_generate_video`, `summer_check_job`.

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Ask the user to play only for what a probe cannot hold an opinion about: whether
 
 1. **using-summer** loads on session start. Sets workflow priority and the red-flag list.
 2. **brainstorm-game** scopes a new project. One question, one page, one direction.
-3. **scene-composition** picks the right hierarchy before any node lands.
+3. **scene-composition** picks the right hierarchy before any node lands; **world-building-3d** places, grounds, spaces, frames, and validates the resulting 3D scene.
 4. **fps-controller / design-mechanic / design-level / setup-multiplayer / vfx** produce the artifact.
 5. **gdscript-patterns** guides every `.gd` write.
 6. **play** runs the game and reports clean or broken.
@@ -360,7 +360,7 @@ The skill bundle replaces "agent flailing through tutorials" with measurable cra
 
 **Process**: `using-summer`, `brainstorm-game`, `debug`, `play`
 
-**Project setup**: `new-project`, `browse-templates`, `make-game`, `scene-composition`
+**Project setup**: `new-project`, `browse-templates`, `make-game`, `scene-composition`, `world-building-3d`
 
 **Build**: `fps-controller`, `design-mechanic`, `design-level`, `design-npc`
 

--- a/skills/scene-and-project/world-building-3d/SKILL.md
+++ b/skills/scene-and-project/world-building-3d/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: world-building-3d
+description: Use when composing, placing, grounding, spacing, framing, or validating 3D objects in Summer Engine scenes. Trigger on "world building", "place props", "snap to floor", "align objects", "distribute objects", "frame camera", "camera visibility", "occlusion", or "navigation reachability".
+license: MIT
+compatibility: [Cursor, Claude Code, Windsurf, Codex]
+category: scene-and-project
+allowed-tools: Read Grep summer_get_scene_tree summer_inspect_node summer_test_placement summer_snap_to_surface summer_align_distribute_3d summer_frame_camera summer_camera_visibility summer_navigation_probe summer_screenshot summer_play
+---
+
+# Build 3D Worlds with Spatial Evidence
+
+Use exact scene and node paths, make one geometric decision at a time, and
+verify the saved result. Spatial tools reduce guesswork but do not replace a
+final rendered or gameplay check.
+
+Read [references/spatial-tools.md](references/spatial-tools.md) before the first
+spatial-tool call in a task. It defines the evidence boundaries and fields that
+must not be overinterpreted.
+
+## Choose the narrowest tool
+
+| Need | Tool | Effect |
+|---|---|---|
+| Evaluate a proposed prop pose | `summer_test_placement` | Read-only ghost pose |
+| Seat one object on a support | `summer_snap_to_surface` | Moves subject and saves |
+| Align or evenly space 2-16 objects | `summer_align_distribute_3d` | Moves subjects and saves |
+| Fit 1-8 subjects in a perspective camera | `summer_frame_camera` | Moves camera and saves |
+| Check framing and coarse occlusion | `summer_camera_visibility` | Read-only |
+| Check whether two positions share a navigation route | `summer_navigation_probe` | Read-only |
+
+Use `summer_get_scene_tree` and `summer_inspect_node` first when paths,
+hierarchy, transforms, collision layers, or camera settings are unknown.
+
+## Follow the composition loop
+
+1. Open the exact target scene and resolve exact `./`-relative paths.
+2. Inspect the subject, visual/collider descendants, support or neighbors, and
+   camera.
+3. State the intended invariant: contact gap, clearance, spacing axis, screen
+   padding, or reachable destination. If the support, ordering, camera, or
+   destination is genuinely ambiguous, ask `Proceed?` with the concrete choice
+   before a user-visible mutation.
+4. Query before mutation when a read-only tool exists.
+5. Apply the smallest mutation. Prefer a dedicated solver over hand-tuned
+   transform loops.
+6. Re-query the saved pose. A successful mutation receipt is not proof of
+   visual quality.
+7. Run a rendered or gameplay check when renderer visibility, transparent
+   materials, concave silhouettes, navigation behavior, or perception matters.
+
+Keep independent scenes independent. Never copy a solved world transform
+between scenes unless their parents, bounds, and obstacles are proven identical.
+
+There is no raw `.tscn` fallback for these evidence queries or solver mutations.
+They depend on the running Summer Engine's live scene, physics, camera, and
+navigation state. If a required tool is unavailable, explain that limitation
+instead of hand-editing a scene around it.
+
+## Place and ground props
+
+For a candidate pose, call `summer_test_placement` before setting the transform.
+Preserve global scale unless the user asked to resize the asset.
+
+- Known overlap evidence means reject the pose.
+- `fits: null` is unknown, never `true`.
+- Require `grounded: true` and an acceptable absolute `floorGap`.
+- `visual_aabb` is broad-phase evidence; irregular meshes can leave empty AABB
+  corners.
+
+For direct seating, use `summer_snap_to_surface` with a world-space direction.
+Set `alignUp: true` only when exact physics support-normal alignment is intended.
+After the call, require `evidence: physics`, resolved contact, the expected
+`supportPath`, `alignApplied`, a plausible `slopeDeg`, and inspect the saved
+`after.basis` plus a rendered view. The result does not return the raw support
+normal or a heading residual. Keep `maxDistance` tight because the solver cannot
+take an expected-support path and stops at the first surface.
+
+On mixed-height or sloped supports, arrange subjects laterally first, then snap
+each subject. A later alignment can lift or bury a grounded prop. Re-query the
+exact saved global pose only when its basis can be represented confidently as
+the placement tool's required global Euler degrees; never invent angles.
+
+## Arrange groups
+
+Pass subjects to `summer_align_distribute_3d` in intentional order and choose a
+world axis explicitly. `align_min`, `align_center`, and `align_max` share one
+projected anchor. `distribute_centers` equalizes centers; `distribute_gaps`
+equalizes visible edge clearance while keeping endpoints fixed. Rerun placement
+checks for dense groups because one-axis alignment does not prove 3D clearance.
+Inspect `changedCount`; infer unchanged subjects as `subjectCount - changedCount`.
+
+## Frame and verify cameras
+
+Call `summer_frame_camera` with the real delivery aspect and explicit padding,
+then `summer_camera_visibility` with the same aspect. Require critical subjects
+to be framed and inspect occlusion separately. Projected rectangles are not
+pixel-visible coverage; five physics rays cannot prove renderer visibility.
+
+## Validate navigation placement
+
+Use `summer_navigation_probe` before moving route-critical NPCs or anchors.
+`ready: false` means unknown. `reachable: false` is meaningful only when ready.
+Require a small requested-to-snapped endpoint distance, then probe the final
+authored position again. Probe each destination separately from the intended
+player/start point, using the final inspected global origin and the scene's
+actual navigation-layer mask. Derive the allowed snap distance from the agent
+radius or an explicit authored tolerance; otherwise report it without calling
+it small. For iteration 0, allow one bounded sync wait and retry once.
+
+## Fail closed
+
+Do not guess around world-mismatch failures such as `subject_world_mismatch` or
+`subject_geometry_world_mismatch`, non-finite transforms, hierarchy limits,
+unavailable physics, or missing-bounds errors. Fix the scene structure or choose
+a clearly labeled manual fallback, then verify it. Do not retry a mutation after
+an oversized or ambiguous result unless it explicitly says retry-safe.

--- a/skills/scene-and-project/world-building-3d/references/spatial-tools.md
+++ b/skills/scene-and-project/world-building-3d/references/spatial-tools.md
@@ -1,0 +1,55 @@
+# Spatial tool evidence contract
+
+Load this reference before using Summer's 3D world-building tools.
+
+## Shared rules
+
+- Pass exact `scenePath` and scene-root-relative node paths. Never rely on
+  editor selection.
+- Use one `World3D`; the tools fail closed across SubViewport-owned worlds.
+- Keep subject counts bounded: placement/snap one, visibility five, framing
+  eight, alignment sixteen.
+- Normal model-visible results stay below 5 KiB.
+- Placement, visibility, and navigation are read-only. Snap, align, and frame
+  register undo and save the exact target scene.
+
+## Placement
+
+`summer_test_placement` evaluates a candidate global position and global Euler
+rotation while preserving current global scale. Physics overlap counts are
+lower bounds because Godot exposes no broadphase-completeness bit. Known
+obstruction means `fits: false`; zero known physics overlaps can still mean
+`fits: null`. Grounding and signed `floorGap` are independent evidence. Claim
+physics-grounded only when `floorEvidence` is `physics` and
+`supportQueryComplete` is true.
+
+## Surface snap
+
+`summer_snap_to_surface` sweeps enabled collider shapes along a normalized world
+direction. `visual_aabb` is a mesh-only fallback and does not provide a trusted
+surface normal. Require physics evidence, resolved contact, expected
+`supportPath`, `alignApplied`, plausible `slopeDeg`, final gap/error bound, and
+saved basis. The result does not expose the raw support normal or heading
+residual, so independently verify the basis and rendered pose.
+
+## Alignment
+
+`summer_align_distribute_3d` uses visible descendant world AABBs, preserves
+basis/scale, and translates only along the requested axis. It is one-dimensional
+evidence and does not prove clearance on the other axes.
+
+## Camera tools
+
+`summer_frame_camera` analytically frames visible world AABBs for a requested
+aspect. `summer_camera_visibility` projects those bounds and samples one to five
+physics rays per subject. Use the same real delivery aspect for both. Shader
+displacement, transparent silhouettes, and pixel visibility remain outside the
+evidence boundary.
+
+## Navigation
+
+`summer_navigation_probe` treats map iteration 0 as unready and iteration 1+
+as queryable. Require both reachable output and an acceptable requested-to-
+snapped endpoint distance. Probe every destination separately and derive the
+distance threshold from navigation-agent radius or an explicit authored
+tolerance.

--- a/skills/scene-and-project/world-building-3d/tests/spec.md
+++ b/skills/scene-and-project/world-building-3d/tests/spec.md
@@ -1,0 +1,50 @@
+# Skill Spec: /world-building-3d
+
+## Fixture
+
+- A 3D scene has props, flat/sloped supports, a perspective camera, colliders,
+  and synchronized navigation.
+- All six spatial tools and ordinary inspection/screenshot tools are available.
+
+## Case 1: Ground mixed props
+
+**Input:** "Seat these crates on the floor, shelf, and ramp without collisions."
+
+**Expected MCP tool sequence (in order):**
+
+1. `summer_get_scene_tree`
+2. `summer_inspect_node` for subjects and supports
+3. `summer_test_placement` for uncertain candidate poses
+4. `summer_snap_to_surface` per subject
+5. `summer_test_placement` at each saved pose
+6. `summer_screenshot`
+
+**Assertions:**
+
+- [ ] Exact scene and node paths are used.
+- [ ] `fits: null` is not treated as clearance proof.
+- [ ] Slope alignment requires physics evidence, resolved contact, expected
+  support, plausible slope, saved-basis inspection, and an independent heading
+  or rendered check.
+- [ ] Ambiguous support choices are confirmed before mutation.
+
+## Case 2: Arrange, frame, and validate navigation
+
+**Input:** "Evenly space these stalls, frame the hero and merchants at 16:9,
+and make sure each merchant is reachable from spawn."
+
+**Expected MCP tool sequence (in order):**
+
+1. `summer_align_distribute_3d`
+2. `summer_test_placement`
+3. `summer_frame_camera` with aspect `1.7777778`
+4. `summer_camera_visibility` with the same aspect
+5. `summer_navigation_probe` per final merchant position
+6. `summer_screenshot` or `summer_play`
+
+**Assertions:**
+
+- [ ] Subject ordering and world axis are explicit.
+- [ ] Framing and sampled occlusion are evaluated separately.
+- [ ] Reachability requires `ready: true` and a small snap distance.
+- [ ] Mutations are followed by saved-pose or rendered verification.

--- a/src/lib/skills-registry.ts
+++ b/src/lib/skills-registry.ts
@@ -131,6 +131,26 @@ export const SKILL_REGISTRY = [
       "Build a small reusable player scene, instantiate it in a main scene, and save both scenes through Summer tools.",
   },
   {
+    name: "world-building-3d",
+    category: "scene-and-project",
+    public: true,
+    clients: ALL_CLIENTS,
+    recommended: true,
+    requiresMcpTools: [
+      "summer_get_scene_tree",
+      "summer_inspect_node",
+      "summer_test_placement",
+      "summer_snap_to_surface",
+      "summer_align_distribute_3d",
+      "summer_frame_camera",
+      "summer_camera_visibility",
+      "summer_navigation_probe",
+      "summer_screenshot",
+    ],
+    testScenario:
+      "Place props on mixed supports, align a group, frame the result, and verify visibility and navigation with bounded spatial evidence.",
+  },
+  {
     name: "summer-cloud",
     category: "scene-and-project",
     public: true,


### PR DESCRIPTION
## What changed

Adds a bundled `world-building-3d` discipline skill and registers it for Claude, Codex, Cursor, and the public skill registry. The skill teaches agents to place, ground, align, frame, and validate 3D scenes with bounded spatial evidence instead of transform guessing.

It documents the evidence boundaries for TestPlacement3D, SnapToSurface, AlignDistribute3D, FrameCamera3D, CameraVisibility3D, and NavigationProbe3D, including exact-scene targeting, compact results, bounded retries, and rendered/gameplay verification.

## Verification

- `npm test -- --run src/lib/plugin-manifests.test.ts` — 11/11 passed
- `npm run build` — passed
- independent skill audit — 7/7 static checks, 2/2 behavioral sequences, 8/8 behavioral assertions
- `git diff --check` — passed

## Rollout dependency

This skill references six new MCP tools. It should not be merged/released to users until the corresponding SummerEngine native/CLI tool suite is merged and a shared engine/CLI release containing those tools is available. No engine behavior is changed by this PR itself.