### PR TITLE
Review bundle: MCP image background removal and stable login test

### DIFF
--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -44,11 +44,12 @@ describe("runLogin", () => {
   it("uses the current browser/poll contract and persists one validated session", async () => {
     const logs: string[] = [];
     const openUrl = vi.fn(async () => undefined);
+    const token = cliToken();
     const fetchMock = vi.fn(async () =>
       new Response(
         JSON.stringify({
           status: "complete",
-          token: cliToken(),
+          token,
           user: {
             id: "user-1",
             email: "maker@example.com",
@@ -74,7 +75,7 @@ describe("runLogin", () => {
       "https://gateway.example/api/auth/cli-login?session=session-123",
       expect.any(Object)
     );
-    expect(await getAuthToken()).toBe(cliToken());
+    expect(await getAuthToken()).toBe(token);
     expect(await getUserInfo()).toMatchObject({
       id: "user-1",
       email: "maker@example.com",

--- a/src/mcp/tools/generate-tools.test.ts
+++ b/src/mcp/tools/generate-tools.test.ts
@@ -378,3 +378,51 @@ describe("registerGenerateTools — provider validation errors", () => {
     expect((init.headers as any)["X-Summer-Client-Version"]).toMatch(/\d+\.\d+\.\d+/);
   });
 });
+
+describe("registerGenerateTools — summer_generate_image removeBackground", () => {
+  it("exposes the flag in the schema and warns about fake checkerboards", () => {
+    const { server, tools } = createFakeServer();
+    registerGenerateTools(server as any);
+
+    const image = getTool(tools, "summer_generate_image");
+    expect(image.schema.removeBackground).toBeDefined();
+    expect(image.description).toContain("removeBackground: true");
+    expect(image.description).toContain("checkerboard");
+  });
+
+  it("forwards removeBackground: true in the request body", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ success: true, asset: { id: "a1" } }),
+    }));
+    globalThis.fetch = fetchMock as any;
+
+    const { server, tools } = createFakeServer();
+    registerGenerateTools(server as any);
+    const image = getTool(tools, "summer_generate_image");
+
+    await image.handler({ prompt: "hooded figure sprite", removeBackground: true });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string).removeBackground).toBe(true);
+  });
+
+  it("omits the key entirely when the flag is not passed", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ success: true, asset: { id: "a2" } }),
+    }));
+    globalThis.fetch = fetchMock as any;
+
+    const { server, tools } = createFakeServer();
+    registerGenerateTools(server as any);
+    const image = getTool(tools, "summer_generate_image");
+
+    await image.handler({ prompt: "forest floor texture" });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).not.toHaveProperty("removeBackground");
+  });
+});

--- a/src/mcp/tools/generate-tools.ts
+++ b/src/mcp/tools/generate-tools.ts
@@ -342,6 +342,13 @@ Two modes:
 
 Style presets: "realistic" (default), "cartoon", "anime", "none"
 
+Transparent backgrounds: image models CANNOT output an alpha channel. If the
+prompt asks for a "transparent background", the model paints a fake grey
+checkerboard into the pixels instead — unusable as a sprite. For sprites,
+icons, and isolated objects set removeBackground: true and keep transparency
+wording OUT of the prompt: Summer strips the background server-side and
+returns a real alpha PNG.
+
 The 'options' object is passed directly to the AI provider for full control.
 
 Returns the asset with fileUrl (hosted) and localPath (temp file on disk).
@@ -363,17 +370,24 @@ Requires authentication: run 'npx summer-engine login' first.`,
         .string()
         .optional()
         .describe("Source image URL for img2img / edit mode. The prompt describes how to transform this image."),
+      removeBackground: z
+        .boolean()
+        .optional()
+        .describe(
+          "Set true for sprites, icons, or isolated objects that need a real transparent background (alpha PNG). Do NOT ask for transparency in the prompt — models bake a fake checkerboard into the pixels instead."
+        ),
       options: z
         .record(z.any())
         .optional()
         .describe("Provider-specific params (guidance_scale, seed, image_size, negative_prompt, etc.)"),
     },
-    async ({ prompt, model, style, referenceImageUrl, options }) => {
+    async ({ prompt, model, style, referenceImageUrl, removeBackground, options }) => {
       const result = await mcpGenerate("/api/mcp/generate/image", {
         prompt,
         model,
         style,
         referenceImageUrl,
+        removeBackground,
         options,
       });
 


### PR DESCRIPTION
## Coordinated review PRs

- Web: https://github.com/SummerEngine/PublicSummerEngine/pull/372
- Native editor: https://github.com/SummerEngine/SummerEngine/pull/195
- CLI/MCP agent: https://github.com/SummerEngine/summer-engine-agent/pull/20

These three drafts use `codex/pr-integration-20260909` in their respective repositories. Review together; native first, then web for the coordinated reliability release. The web aggregate also includes optional billing, whose financial release conditions must be resolved before shipping that aggregate. Agent package publication is a separate release step.

## What this changes

Adds the first-class optional boolean `removeBackground` parameter to `summer_generate_image` and forwards it to the generation request. MCP callers can request background removal through the supported schema rather than relying on prompt wording. The existing behavior remains when the parameter is omitted.

This small draft is the MCP companion to the combined native/web integration review. It does not publish an npm package or deploy anything.

## Included PR

| Source PR | Included head |
| --- | --- |
| [#15: feat(mcp): expose removeBackground on summer_generate_image](https://github.com/SummerEngine/summer-engine-agent/pull/15) | `81a8fa826282` |

The exact source head is an ancestor of this branch. Do not merge source #15 separately after this aggregate lands.

## Fix added during integration

`7cdf3f4`: the login test generated the expected JWT again after the stored fixture was created. Crossing a one-second boundary changed the expiry and made the assertion flaky. The test now compares against the original fixture; production login behavior is unchanged.

## Main synchronization and verification

Freshly fetched `origin/main` `e49189b93fcfee88b57e22ba8467cc782b292ac0` is already an ancestor of `7cdf3f4c97dd15e80842ab5d87d8df1acc2dfd7e`; zero main commits are missing. Exact current source PR head was rechecked on September 10.

- `npm test`: **438 tests / 47 files passed** on this unchanged final head.
- `npm run build`: passed earlier on the same head; generated MCP schema exposes `summer_generate_image.removeBackground` as boolean.
- Actual project-scoped MCP launch/stop/diagnostics worked with the paired editor during the desktop campaign.
- No paid provider call exercising `removeBackground` was made. Schema/forwarding coverage is not a claim of live provider background-removal verification.

Review the optional schema and payload forwarding first; the only additional change is the deterministic JWT test fixture. Package publication/versioning and coordinated rollout remain a release-owner decision.

AI assistance disclosure: Codex performed integration, the test-fixture correction and local verification under Tim's direction.
