### PR TITLE
Generated skills index: human view of the flat library

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ matchmaking are not promised by this package.
 | `summer list templates` / `projects` | Browse. |
 | `summer events [--follow] [--kinds <csv>] [--since <seq>] [--json]` | The engine events channel (engine 0.5.66+): newest events, or stream them live. |
 | `summer debug [issue…]` | Support-ready Markdown debug report. |
-| `summer skills list` | Show all skills. |
+| `summer skills list` | Show all skills (`--by-domain` groups them; the same grouping is in [`library/skills/README.md`](library/skills/README.md)). |
 | `summer skills install <name>` | Install one. |
 | `summer skills install --all --agent <agent>` / `--recommended` [`--stable-only`] | Install every skill (preview included and labelled), or only the recommended subset; `--stable-only` skips preview skills. |
 | `summer tool <name> --args '<json>'` | Run any Summer tool from the shell — the same implementation the MCP tool uses. `summer tool --list` prints them all. |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -55,8 +55,13 @@ Supported agents: `summer`, `claude-code`, `codex`, `cursor`, `windsurf`, `antig
 ## Registry
 
 One source of truth: `library/skills/<slug>/` (`resource.yaml` + `SKILL.md`).
+The folder is flat by design (categories are `facets.domains`, see
+`docs/design/DECISIONS.md` D3); the human view is the generated
+[`library/skills/README.md`](../library/skills/README.md), one section per
+primary domain, and `summer skills list --by-domain` in the terminal.
 Everything else is compiled from it by `npm run generate:registry`:
 
+- `library/skills/README.md`: the browsable index above (`skills-index.md`).
 - `registry/generated/skills-registry.json`: what `summer skills list/install`
   and `summer setup` read (all agents, plugin and non-plugin).
 - `.claude-plugin/plugin.json` `skills:` (plus the `.codex-plugin/`,

--- a/library/skills/README.md
+++ b/library/skills/README.md
@@ -1,0 +1,242 @@
+# Summer skills
+
+> 94 skills, grouped by their primary domain. **Generated** by `npm run generate:registry` from each skill's `resource.yaml`; `--check` fails when this file and the library disagree. Do not edit by hand.
+
+The folder is flat on purpose (`docs/design/DECISIONS.md`, D3): a skill usually belongs to several domains, so categories live in each skill's `facets.domains` and this index is rendered from them. The first domain listed is the primary one. `summer skills list --by-domain` prints the same grouping; `summer skills info <slug>` shows one skill.
+
+Status: **stable** unless marked; *preview* = not yet exercised in-engine by the Summer team; ~~deprecated~~ installs only by name. ★ = installed by `--recommended`.
+
+## Domains
+
+- [2d](#2d) (10)
+- [3d](#3d) (6)
+- [agent-workflow](#agent-workflow) (17)
+- [ai](#ai) (1)
+- [animation](#animation) (6)
+- [assets](#assets) (3)
+- [audio](#audio) (6)
+- [character-controller](#character-controller) (1)
+- [debug](#debug) (1)
+- [deployment](#deployment) (2)
+- [editor](#editor) (1)
+- [gameplay](#gameplay) (3)
+- [level-design](#level-design) (2)
+- [multiplayer](#multiplayer) (3)
+- [navigation](#navigation) (1)
+- [performance](#performance) (1)
+- [rendering](#rendering) (4)
+- [runtime](#runtime) (1)
+- [scenes](#scenes) (11)
+- [scripting](#scripting) (1)
+- [ui](#ui) (1)
+- [vfx](#vfx) (9)
+- [video](#video) (3)
+
+## 2d
+
+| skill | when to use | also |
+|---|---|---|
+| [character-portrait](./character-portrait/SKILL.md) ★ | Generate a single polished character bust for dialogue UI, character select, lore cards, or codex entries. One character, locked composition, VN-style. | assets |
+| [concept-art](./concept-art/SKILL.md) ★ | Explore art direction with 3-4 rough concept variants of a character, environment, or prop to pick a vibe before committing to a final asset. | assets |
+| [create-asset-sheet](./create-asset-sheet/SKILL.md) | Generate a pack of 2D game assets from one prompt — tile sheet, UI kit, character pack, or biome set — sliced, classified, and saved as one pack ArtAsset. | assets |
+| [instantiate-asset-pack](./instantiate-asset-pack/SKILL.md) | Import a whole create-asset-sheet pack into the scene: groups composites, sorts paint order, emits Sprite2D/Node2D/NinePatchRect ops to lay it out. | assets |
+| [pixel-art](./pixel-art/SKILL.md) ★ | Generate pixel-art assets — sprites, items, tiles, portraits — at a specific resolution with pixel-perfect grid, limited palette, retro feel. | assets |
+| [skybox-panorama](./skybox-panorama/SKILL.md) | Generate a 360-degree equirectangular sky panorama and wire it as a PanoramaSkyMaterial Sky resource on WorldEnvironment in a 3D scene. | assets |
+| [sprite-sheet](./sprite-sheet/SKILL.md) | Generate animated 2D character sprites laid out as a sprite sheet — walk cycle, attack, idle, death — wired into AnimatedSprite2D / SpriteFrames. | assets |
+| [tileable-texture](./tileable-texture/SKILL.md) | Generate a seamless tileable texture for walls, floors, or terrain — repeats cleanly on all four edges, wired as a StandardMaterial3D albedo. | assets |
+| [ui-graphics](./ui-graphics/SKILL.md) | Generate game-UI elements — icons, buttons, panels, frames, HUD widgets, badges — flat design, transparent background, wired via TextureRect/NinePatchRect. | assets |
+| [use-widget-asset](./use-widget-asset/SKILL.md) | Wire a widget slice from a create-asset-sheet pack (panel, button, slider, bar, toggle) into NinePatchRect, TextureProgressBar, or TextureRect via sliceMeta. | assets |
+
+## 3d
+
+| skill | when to use | also |
+|---|---|---|
+| [character-model](./character-model/SKILL.md) ★ | Generate a rigged humanoid — player, NPC, enemy, boss — via T-pose reference, user-gated preview, and Meshy auto-rig, wired as CharacterBody3D or Node3D. | assets |
+| [environment-kit](./environment-kit/SKILL.md) | Generate a modular environment kit — wall pieces, floor tiles, pillars, doors, arches, corners — snap-together meshes sharing one visual style. | assets |
+| [*fabricating-assets*](./fabricating-assets/SKILL.md) (preview) | Fabricate meshes with a bpy script in the user's own Blender (summer_fabricate_3d) — kits with exact dimensions, VFX meshes, post-processing generated models. | assets, scripting, agent-workflow |
+| [organic-model](./organic-model/SKILL.md) | Generate organic 3D shapes — trees, rocks, mushrooms, coral, plants, vines, crystals — where AI artifacts read as natural irregularity. | assets |
+| [prop-model](./prop-model/SKILL.md) ★ | Generate a single static 3D prop — sword, barrel, chest, lantern, throne, statue — one isolated object, no rigging, wired as a MeshInstance3D. | assets |
+| [vehicle-model](./vehicle-model/SKILL.md) | Generate a hard-surface vehicle — car, spaceship, mech, boat, tank — static mesh with optional detail-texture pass, wired as Vehicle3D or MeshInstance3D. | assets |
+
+## agent-workflow
+
+| skill | when to use | also |
+|---|---|---|
+| [brainstorming](./brainstorming/SKILL.md) ★ | Explore user intent, requirements, and design before implementation — must run before any creative work: features, components, mechanics, behavior. | game-design |
+| [debugging-game-feel](./debugging-game-feel/SKILL.md) | Debug features that work but feel wrong — floaty jumps, mushy combat, sluggish camera — subjective bugs living in tuning, timing, and feedback layers. | gameplay |
+| [diagnosing-perf-regressions](./diagnosing-perf-regressions/SKILL.md) | Find why frame rate, frame time, or load time got worse since a known-good state — regression hunting, not general performance tuning. | performance |
+| [dispatching-parallel-agents](./dispatching-parallel-agents/SKILL.md) | Work 2+ independent tasks in parallel when they share no state and have no sequential dependencies. | meta |
+| [gameskill](./gameskill/SKILL.md) | Capture what a game-dev session just learned as a reusable skill (project, user or Summer library) so the next session starts smarter. | meta |
+| [*godogen-visual-proof-game-generation*](./godogen-visual-proof-game-generation/SKILL.md) (preview) | Godogen-style game generation with a visual QC loop — capture frames from the running game, self-verify against the brief, bounded fix rounds, proof clip. | verification |
+| [headless-scripting](./headless-scripting/SKILL.md) ★ | Run a GDScript file against Summer Engine from the shell for operations no MCP tool exposes — navmesh baking, collision shapes, TileSets, re-imports. | headless |
+| [investigating-bugs](./investigating-bugs/SKILL.md) ★ | Systematic investigation of any bug, test failure, or unexpected behavior before proposing fixes. | debug |
+| [playtesting-a-feature](./playtesting-a-feature/SKILL.md) ★ | Before claiming a gameplay feature done: actually run the game and walk through the feature. Static diagnostics and type checks do not count. | verification |
+| [running-in-the-cloud](./running-in-the-cloud/SKILL.md) | Run Summer Engine on a Linux box with no display — install it, launch headless, know when xvfb + software GL are needed, authenticate without a browser. | project |
+| [skill-create](./skill-create/SKILL.md) | Bootstrap a new Summer library skill (library/skills/<slug>/ with resource.yaml and SKILL.md), frontmatter, and stub sections. | meta |
+| [skill-improve](./skill-improve/SKILL.md) | Upgrade an underperforming Summer skill — run it against a behavioral spec with and without changes via a parallel-eval harness; ship the winner. | meta |
+| [skill-test](./skill-test/SKILL.md) | Lint a Summer skill before commit, audit the whole library, or check a behavioral spec assertion — static structural rules plus behavioral specs. | meta |
+| [using-summer](./using-summer/SKILL.md) | Session bootstrap for Summer projects — establishes how to find and use Summer skills and the summer-engine MCP before any response. | meta |
+| [verification-before-completion](./verification-before-completion/SKILL.md) ★ | Run verification commands and confirm output before claiming work complete, fixed, or passing — evidence before assertions, always. | verification |
+| [writing-plans](./writing-plans/SKILL.md) | Turn a spec or requirements for a multi-step task into a written implementation plan before touching code. | meta |
+| [writing-skills](./writing-skills/SKILL.md) | Create, edit, and verify agent skills — format, structure, testing with subagents, and best practices. | meta |
+
+## ai
+
+| skill | when to use | also |
+|---|---|---|
+| [design-npc](./design-npc/SKILL.md) ★ | Design enemy/NPC/boss/companion behavior — perception, personality, intent, action state machine, telegraphs — outputs a GDScript stub plus node tree. | npc |
+
+## animation
+
+| skill | when to use | also |
+|---|---|---|
+| [animation-tree](./animation-tree/SKILL.md) | Design and wire AnimationTree state machines and blend trees so clips respond to gameplay — locomotion blends, attack interrupts, hit reactions. | 3d |
+| [character-animation-wiring](./character-animation-wiring/SKILL.md) | Wire a rigged, animated character end to end — inspect real clips and bones, locomotion state machine, method-track events, poses, blend shapes, root motion. | 3d |
+| [facial-and-lipsync](./facial-and-lipsync/SKILL.md) | Make a character's mouth move with a voice-over — phoneme extraction from audio, viseme blendshape mapping, and emotional facial expressions. | 3d |
+| [generate-motion](./generate-motion/SKILL.md) ★ | Attach an animation clip to a rigged character from the curated Meshy motion library — idle, walk, run, attack — wired via AnimationPlayer. | 3d |
+| [procedural-animation](./procedural-animation/SKILL.md) | Runtime bone modification on top of clips — head look-at, foot IK, hand-grabs-prop, additive lean, recoil. Code-and-modifier patterns, not generation. | 3d |
+| [retarget](./retarget/SKILL.md) | Apply existing animation clips from one rigged character to a different rigged character — same library, multiple models, no regeneration. | 3d |
+
+## assets
+
+| skill | when to use | also |
+|---|---|---|
+| [asset-strategy](./asset-strategy/SKILL.md) ★ | Route any 'I need a [thing]' asset request to the right specialist skill — disambiguates 2D / 3D / audio / video / VFX / animation pipelines. | pipeline |
+| [*lumera-single-image-scene-reconstruction*](./lumera-single-image-scene-reconstruction/SKILL.md) (preview) | Lumera-style single image to editable 3D scene — VLM-parsed object boxes and parametric lights, per-object meshes, HDR probe, .tscn assembly, refinement loop. | pipeline, 3d, scenes |
+| [*skintokens-auto-rigging*](./skintokens-auto-rigging/SKILL.md) (preview) | Offline auto-rigging with skin-tokens.cpp (GGML SkinTokens/TokenRig port) — skeleton and skin weights from a static GLB mesh on CPU/Vulkan, into Godot 4. | pipeline, 3d, animation |
+
+## audio
+
+| skill | when to use | also |
+|---|---|---|
+| [adaptive-music](./adaptive-music/SKILL.md) | Wire music stems to game state — combat/explore/boss/tension crossfades on a shared bus, paired with a state machine and AudioBus structure. | gameplay |
+| [ambient-bed](./ambient-bed/SKILL.md) | Generate a long looping location ambience — forest, dungeon, city, spaceship, cave — a looping AudioStreamPlayer on the Ambient bus with a seamless loop. | assets |
+| [audio-direction](./audio-direction/SKILL.md) ★ | Define the game's sonic identity — music style, instruments, SFX vocabulary, dynamic music plan — output as an audio bible at .summer/audio-bible.md. | game-design |
+| [music-track](./music-track/SKILL.md) ★ | Generate a looped or cinematic music track — loops authored at >=30s with a marked loop point, cinematic tracks at >=60s linear. | assets |
+| [sound-effect](./sound-effect/SKILL.md) ★ | Generate short SFX one-shots — footsteps, weapon swings, UI clicks, hit impacts — wired as AudioStreamPlayer/2D/3D that auto-frees on finished. | assets |
+| [voice-line](./voice-line/SKILL.md) ★ | Generate TTS voice lines — NPC barks, narrator, dialogue — with voice-id sourcing, a character-to-voice decision tree, and multi-line dialogue support. | assets |
+
+## character-controller
+
+| skill | when to use | also |
+|---|---|---|
+| [fps-controller](./fps-controller/SKILL.md) ★ | Production-quality first-person controller — WASD, mouse look, jump, coyote time, jump buffering, air control, and external-velocity handling. | gameplay |
+
+## debug
+
+| skill | when to use | also |
+|---|---|---|
+| [debug](./debug/SKILL.md) ★ | Disciplined bug/crash/error loop for Summer projects — script errors, console, debugger, hypothesis, fix, verify — before making code or scene changes. | verification |
+
+## deployment
+
+| skill | when to use | also |
+|---|---|---|
+| [export-and-ship](./export-and-ship/SKILL.md) ★ | Assess and prepare a game export: inventory installed templates and targets, validate release assets and config, produce supported builds after approval. | project |
+| [remote-deploy](./remote-deploy/SKILL.md) ★ | Run or test the game on a real device — phone, tablet, another computer — via the Remote Deploy button, runnable export presets, and on-device debugging. | project |
+
+## editor
+
+| skill | when to use | also |
+|---|---|---|
+| [*driving-the-editor-ui*](./driving-the-editor-ui/SKILL.md) (preview) | Drive the editor UI by name: invoke actions, clear blocking dialogs, switch the main screen, read a dock — and route scene work to the scene tools instead. | agent-workflow, verification |
+
+## gameplay
+
+| skill | when to use | also |
+|---|---|---|
+| [auto-fire-targeting](./auto-fire-targeting/SKILL.md) | Design or fix auto-fire weapon targeting (survivors, top-down ARPG, tower defense) — the pending-damage pattern that prevents over-commit and overkill. | game-design |
+| [*celeste-momentum-platforming*](./celeste-momentum-platforming/SKILL.md) (preview) | Celeste-style 2D precision platformer movement — momentum running, coyote time, variable jumps, dash, wall jump/slide, climb stamina, pixel corner correction. | character-controller, game-design |
+| [design-mechanic](./design-mechanic/SKILL.md) ★ | Design one game mechanic in detail — input, response, feedback, failure modes, depth, tunables — outputs a design doc, node-graph sketch, GDScript stub. | game-design |
+
+## level-design
+
+| skill | when to use | also |
+|---|---|---|
+| [design-level](./design-level/SKILL.md) ★ | Design a single level — layout, pacing, encounters, secrets, reward gating — outputs a level design doc and a node-tree skeleton for summer_create_scene. | game-design |
+| [scene-to-level](./scene-to-level/SKILL.md) | Go from a scene reference image or concept art to a playable scene — orchestrates concept, asset pack, terrain, composition, and scene assembly. | game-design |
+
+## multiplayer
+
+| skill | when to use | also |
+|---|---|---|
+| [host-authoritative-state](./host-authoritative-state/SKILL.md) ★ | Design the state layer of a multiplayer game — what the host owns, how clients request changes, and how the host validates and broadcasts. | game-design |
+| [peer-to-peer-multiplayer](./peer-to-peer-multiplayer/SKILL.md) ★ | Start a multiplayer game from scratch with peer-to-peer host authority — network architecture built top-down, before writing game logic. | project |
+| [setup-multiplayer](./setup-multiplayer/SKILL.md) ★ | Add multiplayer to an existing game — LAN/online co-op, PvP, lobbies — via MultiplayerAPI, MultiplayerSpawner, and MultiplayerSynchronizer. | scripting |
+
+## navigation
+
+| skill | when to use | also |
+|---|---|---|
+| [navigate-summer](./navigate-summer/SKILL.md) ★ | When to open a Summer web page or editor surface FOR the user (billing, their games, the scene just built) versus acting through the API, using summer_open. | agent-workflow, meta |
+
+## performance
+
+| skill | when to use | also |
+|---|---|---|
+| [tune-performance](./tune-performance/SKILL.md) ★ | Profile a slow game via summer_get_diagnostics, identify rendering/physics/scripting hotspots, propose fixes with before/after metric expectations. | debug |
+
+## rendering
+
+| skill | when to use | also |
+|---|---|---|
+| [3d-lighting](./3d-lighting/SKILL.md) ★ | Set up 3D scene lighting — DirectionalLight3D vs Omni vs Spot, WorldEnvironment, sky, shadow tuning, ambient — per current Summer conventions. | lighting |
+| [art-direction](./art-direction/SKILL.md) ★ | Define the game's visual style — references, palette, mood, lighting plan, post-processing, do/don't list — output as an art bible at .summer/art-bible.md. | lighting |
+| [*psx-retro-rendering*](./psx-retro-rendering/SKILL.md) (preview) | Hardware-informed PlayStation 1 rendering in Godot 4 — low-res output, RGB5 and exact dither, affine textures, vertex snapping, blend modes, fog; limits named. | 3d |
+| [*realtime-wet-surfaces*](./realtime-wet-surfaces/SKILL.md) (preview) | Real-time wetness on existing Godot 4 materials without losing their values — value-copying wet shader, geometry-driven wet mask, instance-uniform wet amount. | vfx |
+
+## runtime
+
+| skill | when to use | also |
+|---|---|---|
+| [*agent-playtesting*](./agent-playtesting/SKILL.md) ★ (preview) | Playtest by driving the LIVE game — deterministic launch, frame-stamped probes before/after each action, exact frame steps, scripted or recorded input. | playtest, verification, agent-workflow |
+
+## scenes
+
+| skill | when to use | also |
+|---|---|---|
+| [brainstorm-game](./brainstorm-game/SKILL.md) ★ | Turn a vague idea into a buildable plan — genre, scope, core loop, mechanics, art direction — written as a 1-page brief to .summer/GameSoul.md. | project |
+| [browse-templates](./browse-templates/SKILL.md) ★ | List available Summer Engine project templates, present the choices, and create a project from the chosen one via summer create. | project |
+| [make-game](./make-game/SKILL.md) ★ | Orchestration spine for 'make me a game': brainstorm, plan, scaffold, mechanics, art, audio, polish, verify, ship — delegates to specialist skills. | project |
+| [new-project](./new-project/SKILL.md) ★ | Create a fresh blank Summer Engine project — asks one question (project name) and runs summer create empty. | project |
+| [play](./play/SKILL.md) ★ | Run the project in Summer Engine, wait briefly, then report what's happening — clean run, errors, or warnings. | project |
+| [scene-composition](./scene-composition/SKILL.md) ★ | Scene structure conventions — node hierarchy, when to extract sub-scenes, reusable prefab patterns, and instance-versus-add-node decisions. | project |
+| [*scene-hierarchy-design*](./scene-hierarchy-design/SKILL.md) (preview) | Structure Summer Engine scenes by access pattern — asset vs live hierarchies, wrapper nodes per operation, sub-scenes for reuse, path-agnostic logic. | project, agent-workflow |
+| [*scene-scripting*](./scene-scripting/SKILL.md) ★ (preview) | One GDScript in the live editor (summer_run_script) builds scenes, 2D levels, HUDs and gameplay wiring instead of CRUD chains; verify with diff + screenshot. | scripting, 2d, ui, agent-workflow |
+| [*spatial-placement*](./spatial-placement/SKILL.md) ★ (preview) | Place and verify 3D objects with Starcast evidence — inspect, place, starcast, correct, verify; floor, shelf, wall, alcove recipes and overlap repair. | 3d, world-building, level-design, verification |
+| [*verifying-scenes*](./verifying-scenes/SKILL.md) ★ (preview) | Prove scene work landed — snapshot before, diff + screenshot after (bookmarked viewpoint, labels), live runtime reads during playtests — then claim. | verification, agent-workflow |
+| [*world-building-3d*](./world-building-3d/SKILL.md) ★ (preview) | Compose, ground, space, and validate 3D scenes with Summer's four bounded spatial tools — exact paths, one geometric decision at a time, verified. | 3d, world-building, level-design, verification |
+
+## scripting
+
+| skill | when to use | also |
+|---|---|---|
+| [gdscript-patterns](./gdscript-patterns/SKILL.md) ★ | GDScript conventions — type hints, signals, exports, onready, lifecycle methods, get_node vs $NodePath, naming. | conventions |
+
+## ui
+
+| skill | when to use | also |
+|---|---|---|
+| [ui-basics](./ui-basics/SKILL.md) ★ | Build Summer Engine UI — HUDs, menus, health bars, dialogue boxes, Control trees — anchors, containers, responsive layout, theme vs inline styling. | ux |
+
+## vfx
+
+| skill | when to use | also |
+|---|---|---|
+| [game-feel](./game-feel/SKILL.md) ★ | Add juice: hit-flash, trauma-based camera shake, and audio ducking wired so one hit fires all three — for games that feel flat or lack impact. | gameplay |
+| [vfx-dissolve](./vfx-dissolve/SKILL.md) | Dissolve effect — a mesh disintegrating with a glowing burning edge, driven by a noise-threshold ShaderMaterial overriding the target's material. | rendering |
+| [vfx-fire](./vfx-fire/SKILL.md) ★ | Fire effect — animated flames built with a particle shader, GPUParticles3D, and a noise-based color ramp — torches, campfires, candles. | rendering |
+| [vfx-hit-spark](./vfx-hit-spark/SKILL.md) | Hit-spark effect — a one-shot burst of additive billboard particles oriented to a surface normal, fired on impact. | rendering |
+| [vfx-lightning](./vfx-lightning/SKILL.md) | Lightning bolt effect — procedural jagged path drawn via ImmediateMesh, glow shader, sparks at endpoints, screen shake. | rendering |
+| [vfx-magic-glow](./vfx-magic-glow/SKILL.md) | Magic-glow effect — a pulsing OmniLight3D plus drifting additive motes plus optional emission shader on the source mesh. | rendering |
+| [vfx-muzzle-flash](./vfx-muzzle-flash/SKILL.md) ★ | Muzzle-flash effect — a one-shot ~80 ms burst at a gun barrel built with a particle one-shot or a flashing quad with a star-burst shader. | rendering |
+| [vfx-smoke](./vfx-smoke/SKILL.md) | Smoke effect — a slow-rising column or puff of soft particles built with a noise + density falloff shader on a quad mesh, GPUParticles3D. | rendering |
+| [vfx-water-ripple](./vfx-water-ripple/SKILL.md) | Water-ripple effect — animated normal-distortion ripples on a water plane (or as a Decal) triggered by impacts. | rendering |
+
+## video
+
+| skill | when to use | also |
+|---|---|---|
+| [animated-loop](./animated-loop/SKILL.md) | Generate a short seamlessly-looping video clip — splash background, animated logo backdrop, idle title-screen footage — wired as a looping VideoStreamPlayer. | assets |
+| [cinematic-cutscene](./cinematic-cutscene/SKILL.md) ★ | Generate a non-interactive cutscene — reference-locked look, a 5-10s image-to-video shot, optional TTS dialogue — wired as a fading VideoStreamPlayer. | assets |
+| [trailer-shot](./trailer-shot/SKILL.md) | Generate marketing or trailer footage — slow-mo combat, establishing shots, hero beats, splash screens, pitch-deck B-roll — max punch in 5-10 seconds. | assets |

--- a/registry/generated/skills-index.md
+++ b/registry/generated/skills-index.md
@@ -1,0 +1,242 @@
+# Summer skills
+
+> 94 skills, grouped by their primary domain. **Generated** by `npm run generate:registry` from each skill's `resource.yaml`; `--check` fails when this file and the library disagree. Do not edit by hand.
+
+The folder is flat on purpose (`docs/design/DECISIONS.md`, D3): a skill usually belongs to several domains, so categories live in each skill's `facets.domains` and this index is rendered from them. The first domain listed is the primary one. `summer skills list --by-domain` prints the same grouping; `summer skills info <slug>` shows one skill.
+
+Status: **stable** unless marked; *preview* = not yet exercised in-engine by the Summer team; ~~deprecated~~ installs only by name. ★ = installed by `--recommended`.
+
+## Domains
+
+- [2d](#2d) (10)
+- [3d](#3d) (6)
+- [agent-workflow](#agent-workflow) (17)
+- [ai](#ai) (1)
+- [animation](#animation) (6)
+- [assets](#assets) (3)
+- [audio](#audio) (6)
+- [character-controller](#character-controller) (1)
+- [debug](#debug) (1)
+- [deployment](#deployment) (2)
+- [editor](#editor) (1)
+- [gameplay](#gameplay) (3)
+- [level-design](#level-design) (2)
+- [multiplayer](#multiplayer) (3)
+- [navigation](#navigation) (1)
+- [performance](#performance) (1)
+- [rendering](#rendering) (4)
+- [runtime](#runtime) (1)
+- [scenes](#scenes) (11)
+- [scripting](#scripting) (1)
+- [ui](#ui) (1)
+- [vfx](#vfx) (9)
+- [video](#video) (3)
+
+## 2d
+
+| skill | when to use | also |
+|---|---|---|
+| [character-portrait](./character-portrait/SKILL.md) ★ | Generate a single polished character bust for dialogue UI, character select, lore cards, or codex entries. One character, locked composition, VN-style. | assets |
+| [concept-art](./concept-art/SKILL.md) ★ | Explore art direction with 3-4 rough concept variants of a character, environment, or prop to pick a vibe before committing to a final asset. | assets |
+| [create-asset-sheet](./create-asset-sheet/SKILL.md) | Generate a pack of 2D game assets from one prompt — tile sheet, UI kit, character pack, or biome set — sliced, classified, and saved as one pack ArtAsset. | assets |
+| [instantiate-asset-pack](./instantiate-asset-pack/SKILL.md) | Import a whole create-asset-sheet pack into the scene: groups composites, sorts paint order, emits Sprite2D/Node2D/NinePatchRect ops to lay it out. | assets |
+| [pixel-art](./pixel-art/SKILL.md) ★ | Generate pixel-art assets — sprites, items, tiles, portraits — at a specific resolution with pixel-perfect grid, limited palette, retro feel. | assets |
+| [skybox-panorama](./skybox-panorama/SKILL.md) | Generate a 360-degree equirectangular sky panorama and wire it as a PanoramaSkyMaterial Sky resource on WorldEnvironment in a 3D scene. | assets |
+| [sprite-sheet](./sprite-sheet/SKILL.md) | Generate animated 2D character sprites laid out as a sprite sheet — walk cycle, attack, idle, death — wired into AnimatedSprite2D / SpriteFrames. | assets |
+| [tileable-texture](./tileable-texture/SKILL.md) | Generate a seamless tileable texture for walls, floors, or terrain — repeats cleanly on all four edges, wired as a StandardMaterial3D albedo. | assets |
+| [ui-graphics](./ui-graphics/SKILL.md) | Generate game-UI elements — icons, buttons, panels, frames, HUD widgets, badges — flat design, transparent background, wired via TextureRect/NinePatchRect. | assets |
+| [use-widget-asset](./use-widget-asset/SKILL.md) | Wire a widget slice from a create-asset-sheet pack (panel, button, slider, bar, toggle) into NinePatchRect, TextureProgressBar, or TextureRect via sliceMeta. | assets |
+
+## 3d
+
+| skill | when to use | also |
+|---|---|---|
+| [character-model](./character-model/SKILL.md) ★ | Generate a rigged humanoid — player, NPC, enemy, boss — via T-pose reference, user-gated preview, and Meshy auto-rig, wired as CharacterBody3D or Node3D. | assets |
+| [environment-kit](./environment-kit/SKILL.md) | Generate a modular environment kit — wall pieces, floor tiles, pillars, doors, arches, corners — snap-together meshes sharing one visual style. | assets |
+| [*fabricating-assets*](./fabricating-assets/SKILL.md) (preview) | Fabricate meshes with a bpy script in the user's own Blender (summer_fabricate_3d) — kits with exact dimensions, VFX meshes, post-processing generated models. | assets, scripting, agent-workflow |
+| [organic-model](./organic-model/SKILL.md) | Generate organic 3D shapes — trees, rocks, mushrooms, coral, plants, vines, crystals — where AI artifacts read as natural irregularity. | assets |
+| [prop-model](./prop-model/SKILL.md) ★ | Generate a single static 3D prop — sword, barrel, chest, lantern, throne, statue — one isolated object, no rigging, wired as a MeshInstance3D. | assets |
+| [vehicle-model](./vehicle-model/SKILL.md) | Generate a hard-surface vehicle — car, spaceship, mech, boat, tank — static mesh with optional detail-texture pass, wired as Vehicle3D or MeshInstance3D. | assets |
+
+## agent-workflow
+
+| skill | when to use | also |
+|---|---|---|
+| [brainstorming](./brainstorming/SKILL.md) ★ | Explore user intent, requirements, and design before implementation — must run before any creative work: features, components, mechanics, behavior. | game-design |
+| [debugging-game-feel](./debugging-game-feel/SKILL.md) | Debug features that work but feel wrong — floaty jumps, mushy combat, sluggish camera — subjective bugs living in tuning, timing, and feedback layers. | gameplay |
+| [diagnosing-perf-regressions](./diagnosing-perf-regressions/SKILL.md) | Find why frame rate, frame time, or load time got worse since a known-good state — regression hunting, not general performance tuning. | performance |
+| [dispatching-parallel-agents](./dispatching-parallel-agents/SKILL.md) | Work 2+ independent tasks in parallel when they share no state and have no sequential dependencies. | meta |
+| [gameskill](./gameskill/SKILL.md) | Capture what a game-dev session just learned as a reusable skill (project, user or Summer library) so the next session starts smarter. | meta |
+| [*godogen-visual-proof-game-generation*](./godogen-visual-proof-game-generation/SKILL.md) (preview) | Godogen-style game generation with a visual QC loop — capture frames from the running game, self-verify against the brief, bounded fix rounds, proof clip. | verification |
+| [headless-scripting](./headless-scripting/SKILL.md) ★ | Run a GDScript file against Summer Engine from the shell for operations no MCP tool exposes — navmesh baking, collision shapes, TileSets, re-imports. | headless |
+| [investigating-bugs](./investigating-bugs/SKILL.md) ★ | Systematic investigation of any bug, test failure, or unexpected behavior before proposing fixes. | debug |
+| [playtesting-a-feature](./playtesting-a-feature/SKILL.md) ★ | Before claiming a gameplay feature done: actually run the game and walk through the feature. Static diagnostics and type checks do not count. | verification |
+| [running-in-the-cloud](./running-in-the-cloud/SKILL.md) | Run Summer Engine on a Linux box with no display — install it, launch headless, know when xvfb + software GL are needed, authenticate without a browser. | project |
+| [skill-create](./skill-create/SKILL.md) | Bootstrap a new Summer library skill (library/skills/<slug>/ with resource.yaml and SKILL.md), frontmatter, and stub sections. | meta |
+| [skill-improve](./skill-improve/SKILL.md) | Upgrade an underperforming Summer skill — run it against a behavioral spec with and without changes via a parallel-eval harness; ship the winner. | meta |
+| [skill-test](./skill-test/SKILL.md) | Lint a Summer skill before commit, audit the whole library, or check a behavioral spec assertion — static structural rules plus behavioral specs. | meta |
+| [using-summer](./using-summer/SKILL.md) | Session bootstrap for Summer projects — establishes how to find and use Summer skills and the summer-engine MCP before any response. | meta |
+| [verification-before-completion](./verification-before-completion/SKILL.md) ★ | Run verification commands and confirm output before claiming work complete, fixed, or passing — evidence before assertions, always. | verification |
+| [writing-plans](./writing-plans/SKILL.md) | Turn a spec or requirements for a multi-step task into a written implementation plan before touching code. | meta |
+| [writing-skills](./writing-skills/SKILL.md) | Create, edit, and verify agent skills — format, structure, testing with subagents, and best practices. | meta |
+
+## ai
+
+| skill | when to use | also |
+|---|---|---|
+| [design-npc](./design-npc/SKILL.md) ★ | Design enemy/NPC/boss/companion behavior — perception, personality, intent, action state machine, telegraphs — outputs a GDScript stub plus node tree. | npc |
+
+## animation
+
+| skill | when to use | also |
+|---|---|---|
+| [animation-tree](./animation-tree/SKILL.md) | Design and wire AnimationTree state machines and blend trees so clips respond to gameplay — locomotion blends, attack interrupts, hit reactions. | 3d |
+| [character-animation-wiring](./character-animation-wiring/SKILL.md) | Wire a rigged, animated character end to end — inspect real clips and bones, locomotion state machine, method-track events, poses, blend shapes, root motion. | 3d |
+| [facial-and-lipsync](./facial-and-lipsync/SKILL.md) | Make a character's mouth move with a voice-over — phoneme extraction from audio, viseme blendshape mapping, and emotional facial expressions. | 3d |
+| [generate-motion](./generate-motion/SKILL.md) ★ | Attach an animation clip to a rigged character from the curated Meshy motion library — idle, walk, run, attack — wired via AnimationPlayer. | 3d |
+| [procedural-animation](./procedural-animation/SKILL.md) | Runtime bone modification on top of clips — head look-at, foot IK, hand-grabs-prop, additive lean, recoil. Code-and-modifier patterns, not generation. | 3d |
+| [retarget](./retarget/SKILL.md) | Apply existing animation clips from one rigged character to a different rigged character — same library, multiple models, no regeneration. | 3d |
+
+## assets
+
+| skill | when to use | also |
+|---|---|---|
+| [asset-strategy](./asset-strategy/SKILL.md) ★ | Route any 'I need a [thing]' asset request to the right specialist skill — disambiguates 2D / 3D / audio / video / VFX / animation pipelines. | pipeline |
+| [*lumera-single-image-scene-reconstruction*](./lumera-single-image-scene-reconstruction/SKILL.md) (preview) | Lumera-style single image to editable 3D scene — VLM-parsed object boxes and parametric lights, per-object meshes, HDR probe, .tscn assembly, refinement loop. | pipeline, 3d, scenes |
+| [*skintokens-auto-rigging*](./skintokens-auto-rigging/SKILL.md) (preview) | Offline auto-rigging with skin-tokens.cpp (GGML SkinTokens/TokenRig port) — skeleton and skin weights from a static GLB mesh on CPU/Vulkan, into Godot 4. | pipeline, 3d, animation |
+
+## audio
+
+| skill | when to use | also |
+|---|---|---|
+| [adaptive-music](./adaptive-music/SKILL.md) | Wire music stems to game state — combat/explore/boss/tension crossfades on a shared bus, paired with a state machine and AudioBus structure. | gameplay |
+| [ambient-bed](./ambient-bed/SKILL.md) | Generate a long looping location ambience — forest, dungeon, city, spaceship, cave — a looping AudioStreamPlayer on the Ambient bus with a seamless loop. | assets |
+| [audio-direction](./audio-direction/SKILL.md) ★ | Define the game's sonic identity — music style, instruments, SFX vocabulary, dynamic music plan — output as an audio bible at .summer/audio-bible.md. | game-design |
+| [music-track](./music-track/SKILL.md) ★ | Generate a looped or cinematic music track — loops authored at >=30s with a marked loop point, cinematic tracks at >=60s linear. | assets |
+| [sound-effect](./sound-effect/SKILL.md) ★ | Generate short SFX one-shots — footsteps, weapon swings, UI clicks, hit impacts — wired as AudioStreamPlayer/2D/3D that auto-frees on finished. | assets |
+| [voice-line](./voice-line/SKILL.md) ★ | Generate TTS voice lines — NPC barks, narrator, dialogue — with voice-id sourcing, a character-to-voice decision tree, and multi-line dialogue support. | assets |
+
+## character-controller
+
+| skill | when to use | also |
+|---|---|---|
+| [fps-controller](./fps-controller/SKILL.md) ★ | Production-quality first-person controller — WASD, mouse look, jump, coyote time, jump buffering, air control, and external-velocity handling. | gameplay |
+
+## debug
+
+| skill | when to use | also |
+|---|---|---|
+| [debug](./debug/SKILL.md) ★ | Disciplined bug/crash/error loop for Summer projects — script errors, console, debugger, hypothesis, fix, verify — before making code or scene changes. | verification |
+
+## deployment
+
+| skill | when to use | also |
+|---|---|---|
+| [export-and-ship](./export-and-ship/SKILL.md) ★ | Assess and prepare a game export: inventory installed templates and targets, validate release assets and config, produce supported builds after approval. | project |
+| [remote-deploy](./remote-deploy/SKILL.md) ★ | Run or test the game on a real device — phone, tablet, another computer — via the Remote Deploy button, runnable export presets, and on-device debugging. | project |
+
+## editor
+
+| skill | when to use | also |
+|---|---|---|
+| [*driving-the-editor-ui*](./driving-the-editor-ui/SKILL.md) (preview) | Drive the editor UI by name: invoke actions, clear blocking dialogs, switch the main screen, read a dock — and route scene work to the scene tools instead. | agent-workflow, verification |
+
+## gameplay
+
+| skill | when to use | also |
+|---|---|---|
+| [auto-fire-targeting](./auto-fire-targeting/SKILL.md) | Design or fix auto-fire weapon targeting (survivors, top-down ARPG, tower defense) — the pending-damage pattern that prevents over-commit and overkill. | game-design |
+| [*celeste-momentum-platforming*](./celeste-momentum-platforming/SKILL.md) (preview) | Celeste-style 2D precision platformer movement — momentum running, coyote time, variable jumps, dash, wall jump/slide, climb stamina, pixel corner correction. | character-controller, game-design |
+| [design-mechanic](./design-mechanic/SKILL.md) ★ | Design one game mechanic in detail — input, response, feedback, failure modes, depth, tunables — outputs a design doc, node-graph sketch, GDScript stub. | game-design |
+
+## level-design
+
+| skill | when to use | also |
+|---|---|---|
+| [design-level](./design-level/SKILL.md) ★ | Design a single level — layout, pacing, encounters, secrets, reward gating — outputs a level design doc and a node-tree skeleton for summer_create_scene. | game-design |
+| [scene-to-level](./scene-to-level/SKILL.md) | Go from a scene reference image or concept art to a playable scene — orchestrates concept, asset pack, terrain, composition, and scene assembly. | game-design |
+
+## multiplayer
+
+| skill | when to use | also |
+|---|---|---|
+| [host-authoritative-state](./host-authoritative-state/SKILL.md) ★ | Design the state layer of a multiplayer game — what the host owns, how clients request changes, and how the host validates and broadcasts. | game-design |
+| [peer-to-peer-multiplayer](./peer-to-peer-multiplayer/SKILL.md) ★ | Start a multiplayer game from scratch with peer-to-peer host authority — network architecture built top-down, before writing game logic. | project |
+| [setup-multiplayer](./setup-multiplayer/SKILL.md) ★ | Add multiplayer to an existing game — LAN/online co-op, PvP, lobbies — via MultiplayerAPI, MultiplayerSpawner, and MultiplayerSynchronizer. | scripting |
+
+## navigation
+
+| skill | when to use | also |
+|---|---|---|
+| [navigate-summer](./navigate-summer/SKILL.md) ★ | When to open a Summer web page or editor surface FOR the user (billing, their games, the scene just built) versus acting through the API, using summer_open. | agent-workflow, meta |
+
+## performance
+
+| skill | when to use | also |
+|---|---|---|
+| [tune-performance](./tune-performance/SKILL.md) ★ | Profile a slow game via summer_get_diagnostics, identify rendering/physics/scripting hotspots, propose fixes with before/after metric expectations. | debug |
+
+## rendering
+
+| skill | when to use | also |
+|---|---|---|
+| [3d-lighting](./3d-lighting/SKILL.md) ★ | Set up 3D scene lighting — DirectionalLight3D vs Omni vs Spot, WorldEnvironment, sky, shadow tuning, ambient — per current Summer conventions. | lighting |
+| [art-direction](./art-direction/SKILL.md) ★ | Define the game's visual style — references, palette, mood, lighting plan, post-processing, do/don't list — output as an art bible at .summer/art-bible.md. | lighting |
+| [*psx-retro-rendering*](./psx-retro-rendering/SKILL.md) (preview) | Hardware-informed PlayStation 1 rendering in Godot 4 — low-res output, RGB5 and exact dither, affine textures, vertex snapping, blend modes, fog; limits named. | 3d |
+| [*realtime-wet-surfaces*](./realtime-wet-surfaces/SKILL.md) (preview) | Real-time wetness on existing Godot 4 materials without losing their values — value-copying wet shader, geometry-driven wet mask, instance-uniform wet amount. | vfx |
+
+## runtime
+
+| skill | when to use | also |
+|---|---|---|
+| [*agent-playtesting*](./agent-playtesting/SKILL.md) ★ (preview) | Playtest by driving the LIVE game — deterministic launch, frame-stamped probes before/after each action, exact frame steps, scripted or recorded input. | playtest, verification, agent-workflow |
+
+## scenes
+
+| skill | when to use | also |
+|---|---|---|
+| [brainstorm-game](./brainstorm-game/SKILL.md) ★ | Turn a vague idea into a buildable plan — genre, scope, core loop, mechanics, art direction — written as a 1-page brief to .summer/GameSoul.md. | project |
+| [browse-templates](./browse-templates/SKILL.md) ★ | List available Summer Engine project templates, present the choices, and create a project from the chosen one via summer create. | project |
+| [make-game](./make-game/SKILL.md) ★ | Orchestration spine for 'make me a game': brainstorm, plan, scaffold, mechanics, art, audio, polish, verify, ship — delegates to specialist skills. | project |
+| [new-project](./new-project/SKILL.md) ★ | Create a fresh blank Summer Engine project — asks one question (project name) and runs summer create empty. | project |
+| [play](./play/SKILL.md) ★ | Run the project in Summer Engine, wait briefly, then report what's happening — clean run, errors, or warnings. | project |
+| [scene-composition](./scene-composition/SKILL.md) ★ | Scene structure conventions — node hierarchy, when to extract sub-scenes, reusable prefab patterns, and instance-versus-add-node decisions. | project |
+| [*scene-hierarchy-design*](./scene-hierarchy-design/SKILL.md) (preview) | Structure Summer Engine scenes by access pattern — asset vs live hierarchies, wrapper nodes per operation, sub-scenes for reuse, path-agnostic logic. | project, agent-workflow |
+| [*scene-scripting*](./scene-scripting/SKILL.md) ★ (preview) | One GDScript in the live editor (summer_run_script) builds scenes, 2D levels, HUDs and gameplay wiring instead of CRUD chains; verify with diff + screenshot. | scripting, 2d, ui, agent-workflow |
+| [*spatial-placement*](./spatial-placement/SKILL.md) ★ (preview) | Place and verify 3D objects with Starcast evidence — inspect, place, starcast, correct, verify; floor, shelf, wall, alcove recipes and overlap repair. | 3d, world-building, level-design, verification |
+| [*verifying-scenes*](./verifying-scenes/SKILL.md) ★ (preview) | Prove scene work landed — snapshot before, diff + screenshot after (bookmarked viewpoint, labels), live runtime reads during playtests — then claim. | verification, agent-workflow |
+| [*world-building-3d*](./world-building-3d/SKILL.md) ★ (preview) | Compose, ground, space, and validate 3D scenes with Summer's four bounded spatial tools — exact paths, one geometric decision at a time, verified. | 3d, world-building, level-design, verification |
+
+## scripting
+
+| skill | when to use | also |
+|---|---|---|
+| [gdscript-patterns](./gdscript-patterns/SKILL.md) ★ | GDScript conventions — type hints, signals, exports, onready, lifecycle methods, get_node vs $NodePath, naming. | conventions |
+
+## ui
+
+| skill | when to use | also |
+|---|---|---|
+| [ui-basics](./ui-basics/SKILL.md) ★ | Build Summer Engine UI — HUDs, menus, health bars, dialogue boxes, Control trees — anchors, containers, responsive layout, theme vs inline styling. | ux |
+
+## vfx
+
+| skill | when to use | also |
+|---|---|---|
+| [game-feel](./game-feel/SKILL.md) ★ | Add juice: hit-flash, trauma-based camera shake, and audio ducking wired so one hit fires all three — for games that feel flat or lack impact. | gameplay |
+| [vfx-dissolve](./vfx-dissolve/SKILL.md) | Dissolve effect — a mesh disintegrating with a glowing burning edge, driven by a noise-threshold ShaderMaterial overriding the target's material. | rendering |
+| [vfx-fire](./vfx-fire/SKILL.md) ★ | Fire effect — animated flames built with a particle shader, GPUParticles3D, and a noise-based color ramp — torches, campfires, candles. | rendering |
+| [vfx-hit-spark](./vfx-hit-spark/SKILL.md) | Hit-spark effect — a one-shot burst of additive billboard particles oriented to a surface normal, fired on impact. | rendering |
+| [vfx-lightning](./vfx-lightning/SKILL.md) | Lightning bolt effect — procedural jagged path drawn via ImmediateMesh, glow shader, sparks at endpoints, screen shake. | rendering |
+| [vfx-magic-glow](./vfx-magic-glow/SKILL.md) | Magic-glow effect — a pulsing OmniLight3D plus drifting additive motes plus optional emission shader on the source mesh. | rendering |
+| [vfx-muzzle-flash](./vfx-muzzle-flash/SKILL.md) ★ | Muzzle-flash effect — a one-shot ~80 ms burst at a gun barrel built with a particle one-shot or a flashing quad with a star-burst shader. | rendering |
+| [vfx-smoke](./vfx-smoke/SKILL.md) | Smoke effect — a slow-rising column or puff of soft particles built with a noise + density falloff shader on a quad mesh, GPUParticles3D. | rendering |
+| [vfx-water-ripple](./vfx-water-ripple/SKILL.md) | Water-ripple effect — animated normal-distortion ripples on a water plane (or as a Decal) triggered by impacts. | rendering |
+
+## video
+
+| skill | when to use | also |
+|---|---|---|
+| [animated-loop](./animated-loop/SKILL.md) | Generate a short seamlessly-looping video clip — splash background, animated logo backdrop, idle title-screen footage — wired as a looping VideoStreamPlayer. | assets |
+| [cinematic-cutscene](./cinematic-cutscene/SKILL.md) ★ | Generate a non-interactive cutscene — reference-locked look, a 5-10s image-to-video shot, optional TTS dialogue — wired as a fading VideoStreamPlayer. | assets |
+| [trailer-shot](./trailer-shot/SKILL.md) | Generate marketing or trailer footage — slow-mo combat, establishing shots, hero beats, splash screens, pitch-deck B-roll — max punch in 5-10 seconds. | assets |

--- a/registry/generated/skills-registry.json
+++ b/registry/generated/skills-registry.json
@@ -8,7 +8,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/3d-lighting/"
+      "path": "library/skills/3d-lighting/",
+      "domains": [
+        "rendering",
+        "lighting"
+      ]
     },
     {
       "id": "skill/adaptive-music",
@@ -17,7 +21,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/adaptive-music/"
+      "path": "library/skills/adaptive-music/",
+      "domains": [
+        "audio",
+        "gameplay"
+      ]
     },
     {
       "id": "skill/agent-playtesting",
@@ -26,7 +34,13 @@
       "clients": "all",
       "recommended": true,
       "status": "preview",
-      "path": "library/skills/agent-playtesting/"
+      "path": "library/skills/agent-playtesting/",
+      "domains": [
+        "runtime",
+        "playtest",
+        "verification",
+        "agent-workflow"
+      ]
     },
     {
       "id": "skill/ambient-bed",
@@ -35,7 +49,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/ambient-bed/"
+      "path": "library/skills/ambient-bed/",
+      "domains": [
+        "audio",
+        "assets"
+      ]
     },
     {
       "id": "skill/animated-loop",
@@ -44,7 +62,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/animated-loop/"
+      "path": "library/skills/animated-loop/",
+      "domains": [
+        "video",
+        "assets"
+      ]
     },
     {
       "id": "skill/animation-tree",
@@ -53,7 +75,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/animation-tree/"
+      "path": "library/skills/animation-tree/",
+      "domains": [
+        "animation",
+        "3d"
+      ]
     },
     {
       "id": "skill/art-direction",
@@ -62,7 +88,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/art-direction/"
+      "path": "library/skills/art-direction/",
+      "domains": [
+        "rendering",
+        "lighting"
+      ]
     },
     {
       "id": "skill/asset-strategy",
@@ -71,7 +101,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/asset-strategy/"
+      "path": "library/skills/asset-strategy/",
+      "domains": [
+        "assets",
+        "pipeline"
+      ]
     },
     {
       "id": "skill/audio-direction",
@@ -80,7 +114,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/audio-direction/"
+      "path": "library/skills/audio-direction/",
+      "domains": [
+        "audio",
+        "game-design"
+      ]
     },
     {
       "id": "skill/auto-fire-targeting",
@@ -89,7 +127,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/auto-fire-targeting/"
+      "path": "library/skills/auto-fire-targeting/",
+      "domains": [
+        "gameplay",
+        "game-design"
+      ]
     },
     {
       "id": "skill/brainstorm-game",
@@ -98,7 +140,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/brainstorm-game/"
+      "path": "library/skills/brainstorm-game/",
+      "domains": [
+        "scenes",
+        "project"
+      ]
     },
     {
       "id": "skill/brainstorming",
@@ -107,7 +153,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/brainstorming/"
+      "path": "library/skills/brainstorming/",
+      "domains": [
+        "agent-workflow",
+        "game-design"
+      ]
     },
     {
       "id": "skill/browse-templates",
@@ -116,7 +166,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/browse-templates/"
+      "path": "library/skills/browse-templates/",
+      "domains": [
+        "scenes",
+        "project"
+      ]
     },
     {
       "id": "skill/celeste-momentum-platforming",
@@ -125,7 +179,12 @@
       "clients": "all",
       "recommended": false,
       "status": "preview",
-      "path": "library/skills/celeste-momentum-platforming/"
+      "path": "library/skills/celeste-momentum-platforming/",
+      "domains": [
+        "gameplay",
+        "character-controller",
+        "game-design"
+      ]
     },
     {
       "id": "skill/character-animation-wiring",
@@ -134,7 +193,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/character-animation-wiring/"
+      "path": "library/skills/character-animation-wiring/",
+      "domains": [
+        "animation",
+        "3d"
+      ]
     },
     {
       "id": "skill/character-model",
@@ -143,7 +206,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/character-model/"
+      "path": "library/skills/character-model/",
+      "domains": [
+        "3d",
+        "assets"
+      ]
     },
     {
       "id": "skill/character-portrait",
@@ -152,7 +219,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/character-portrait/"
+      "path": "library/skills/character-portrait/",
+      "domains": [
+        "2d",
+        "assets"
+      ]
     },
     {
       "id": "skill/cinematic-cutscene",
@@ -161,7 +232,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/cinematic-cutscene/"
+      "path": "library/skills/cinematic-cutscene/",
+      "domains": [
+        "video",
+        "assets"
+      ]
     },
     {
       "id": "skill/concept-art",
@@ -170,7 +245,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/concept-art/"
+      "path": "library/skills/concept-art/",
+      "domains": [
+        "2d",
+        "assets"
+      ]
     },
     {
       "id": "skill/create-asset-sheet",
@@ -179,7 +258,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/create-asset-sheet/"
+      "path": "library/skills/create-asset-sheet/",
+      "domains": [
+        "2d",
+        "assets"
+      ]
     },
     {
       "id": "skill/debug",
@@ -188,7 +271,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/debug/"
+      "path": "library/skills/debug/",
+      "domains": [
+        "debug",
+        "verification"
+      ]
     },
     {
       "id": "skill/debugging-game-feel",
@@ -197,7 +284,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/debugging-game-feel/"
+      "path": "library/skills/debugging-game-feel/",
+      "domains": [
+        "agent-workflow",
+        "gameplay"
+      ]
     },
     {
       "id": "skill/design-level",
@@ -206,7 +297,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/design-level/"
+      "path": "library/skills/design-level/",
+      "domains": [
+        "level-design",
+        "game-design"
+      ]
     },
     {
       "id": "skill/design-mechanic",
@@ -215,7 +310,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/design-mechanic/"
+      "path": "library/skills/design-mechanic/",
+      "domains": [
+        "gameplay",
+        "game-design"
+      ]
     },
     {
       "id": "skill/design-npc",
@@ -224,7 +323,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/design-npc/"
+      "path": "library/skills/design-npc/",
+      "domains": [
+        "ai",
+        "npc"
+      ]
     },
     {
       "id": "skill/diagnosing-perf-regressions",
@@ -233,7 +336,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/diagnosing-perf-regressions/"
+      "path": "library/skills/diagnosing-perf-regressions/",
+      "domains": [
+        "agent-workflow",
+        "performance"
+      ]
     },
     {
       "id": "skill/dispatching-parallel-agents",
@@ -242,7 +349,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/dispatching-parallel-agents/"
+      "path": "library/skills/dispatching-parallel-agents/",
+      "domains": [
+        "agent-workflow",
+        "meta"
+      ]
     },
     {
       "id": "skill/driving-the-editor-ui",
@@ -251,7 +362,12 @@
       "clients": "all",
       "recommended": false,
       "status": "preview",
-      "path": "library/skills/driving-the-editor-ui/"
+      "path": "library/skills/driving-the-editor-ui/",
+      "domains": [
+        "editor",
+        "agent-workflow",
+        "verification"
+      ]
     },
     {
       "id": "skill/environment-kit",
@@ -260,7 +376,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/environment-kit/"
+      "path": "library/skills/environment-kit/",
+      "domains": [
+        "3d",
+        "assets"
+      ]
     },
     {
       "id": "skill/export-and-ship",
@@ -269,7 +389,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/export-and-ship/"
+      "path": "library/skills/export-and-ship/",
+      "domains": [
+        "deployment",
+        "project"
+      ]
     },
     {
       "id": "skill/fabricating-assets",
@@ -278,7 +402,13 @@
       "clients": "all",
       "recommended": false,
       "status": "preview",
-      "path": "library/skills/fabricating-assets/"
+      "path": "library/skills/fabricating-assets/",
+      "domains": [
+        "3d",
+        "assets",
+        "scripting",
+        "agent-workflow"
+      ]
     },
     {
       "id": "skill/facial-and-lipsync",
@@ -287,7 +417,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/facial-and-lipsync/"
+      "path": "library/skills/facial-and-lipsync/",
+      "domains": [
+        "animation",
+        "3d"
+      ]
     },
     {
       "id": "skill/fps-controller",
@@ -296,7 +430,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/fps-controller/"
+      "path": "library/skills/fps-controller/",
+      "domains": [
+        "character-controller",
+        "gameplay"
+      ]
     },
     {
       "id": "skill/game-feel",
@@ -305,7 +443,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/game-feel/"
+      "path": "library/skills/game-feel/",
+      "domains": [
+        "vfx",
+        "gameplay"
+      ]
     },
     {
       "id": "skill/gameskill",
@@ -314,7 +456,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/gameskill/"
+      "path": "library/skills/gameskill/",
+      "domains": [
+        "agent-workflow",
+        "meta"
+      ]
     },
     {
       "id": "skill/gdscript-patterns",
@@ -323,7 +469,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/gdscript-patterns/"
+      "path": "library/skills/gdscript-patterns/",
+      "domains": [
+        "scripting",
+        "conventions"
+      ]
     },
     {
       "id": "skill/generate-motion",
@@ -332,7 +482,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/generate-motion/"
+      "path": "library/skills/generate-motion/",
+      "domains": [
+        "animation",
+        "3d"
+      ]
     },
     {
       "id": "skill/godogen-visual-proof-game-generation",
@@ -341,7 +495,11 @@
       "clients": "all",
       "recommended": false,
       "status": "preview",
-      "path": "library/skills/godogen-visual-proof-game-generation/"
+      "path": "library/skills/godogen-visual-proof-game-generation/",
+      "domains": [
+        "agent-workflow",
+        "verification"
+      ]
     },
     {
       "id": "skill/headless-scripting",
@@ -350,7 +508,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/headless-scripting/"
+      "path": "library/skills/headless-scripting/",
+      "domains": [
+        "agent-workflow",
+        "headless"
+      ]
     },
     {
       "id": "skill/host-authoritative-state",
@@ -359,7 +521,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/host-authoritative-state/"
+      "path": "library/skills/host-authoritative-state/",
+      "domains": [
+        "multiplayer",
+        "game-design"
+      ]
     },
     {
       "id": "skill/instantiate-asset-pack",
@@ -368,7 +534,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/instantiate-asset-pack/"
+      "path": "library/skills/instantiate-asset-pack/",
+      "domains": [
+        "2d",
+        "assets"
+      ]
     },
     {
       "id": "skill/investigating-bugs",
@@ -377,7 +547,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/investigating-bugs/"
+      "path": "library/skills/investigating-bugs/",
+      "domains": [
+        "agent-workflow",
+        "debug"
+      ]
     },
     {
       "id": "skill/lumera-single-image-scene-reconstruction",
@@ -386,7 +560,13 @@
       "clients": "all",
       "recommended": false,
       "status": "preview",
-      "path": "library/skills/lumera-single-image-scene-reconstruction/"
+      "path": "library/skills/lumera-single-image-scene-reconstruction/",
+      "domains": [
+        "assets",
+        "pipeline",
+        "3d",
+        "scenes"
+      ]
     },
     {
       "id": "skill/make-game",
@@ -395,7 +575,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/make-game/"
+      "path": "library/skills/make-game/",
+      "domains": [
+        "scenes",
+        "project"
+      ]
     },
     {
       "id": "skill/music-track",
@@ -404,7 +588,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/music-track/"
+      "path": "library/skills/music-track/",
+      "domains": [
+        "audio",
+        "assets"
+      ]
     },
     {
       "id": "skill/navigate-summer",
@@ -413,7 +601,12 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/navigate-summer/"
+      "path": "library/skills/navigate-summer/",
+      "domains": [
+        "navigation",
+        "agent-workflow",
+        "meta"
+      ]
     },
     {
       "id": "skill/new-project",
@@ -422,7 +615,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/new-project/"
+      "path": "library/skills/new-project/",
+      "domains": [
+        "scenes",
+        "project"
+      ]
     },
     {
       "id": "skill/organic-model",
@@ -431,7 +628,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/organic-model/"
+      "path": "library/skills/organic-model/",
+      "domains": [
+        "3d",
+        "assets"
+      ]
     },
     {
       "id": "skill/peer-to-peer-multiplayer",
@@ -440,7 +641,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/peer-to-peer-multiplayer/"
+      "path": "library/skills/peer-to-peer-multiplayer/",
+      "domains": [
+        "multiplayer",
+        "project"
+      ]
     },
     {
       "id": "skill/pixel-art",
@@ -449,7 +654,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/pixel-art/"
+      "path": "library/skills/pixel-art/",
+      "domains": [
+        "2d",
+        "assets"
+      ]
     },
     {
       "id": "skill/play",
@@ -458,7 +667,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/play/"
+      "path": "library/skills/play/",
+      "domains": [
+        "scenes",
+        "project"
+      ]
     },
     {
       "id": "skill/playtesting-a-feature",
@@ -467,7 +680,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/playtesting-a-feature/"
+      "path": "library/skills/playtesting-a-feature/",
+      "domains": [
+        "agent-workflow",
+        "verification"
+      ]
     },
     {
       "id": "skill/procedural-animation",
@@ -476,7 +693,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/procedural-animation/"
+      "path": "library/skills/procedural-animation/",
+      "domains": [
+        "animation",
+        "3d"
+      ]
     },
     {
       "id": "skill/prop-model",
@@ -485,7 +706,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/prop-model/"
+      "path": "library/skills/prop-model/",
+      "domains": [
+        "3d",
+        "assets"
+      ]
     },
     {
       "id": "skill/psx-retro-rendering",
@@ -494,7 +719,11 @@
       "clients": "all",
       "recommended": false,
       "status": "preview",
-      "path": "library/skills/psx-retro-rendering/"
+      "path": "library/skills/psx-retro-rendering/",
+      "domains": [
+        "rendering",
+        "3d"
+      ]
     },
     {
       "id": "skill/realtime-wet-surfaces",
@@ -503,7 +732,11 @@
       "clients": "all",
       "recommended": false,
       "status": "preview",
-      "path": "library/skills/realtime-wet-surfaces/"
+      "path": "library/skills/realtime-wet-surfaces/",
+      "domains": [
+        "rendering",
+        "vfx"
+      ]
     },
     {
       "id": "skill/remote-deploy",
@@ -512,7 +745,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/remote-deploy/"
+      "path": "library/skills/remote-deploy/",
+      "domains": [
+        "deployment",
+        "project"
+      ]
     },
     {
       "id": "skill/retarget",
@@ -521,7 +758,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/retarget/"
+      "path": "library/skills/retarget/",
+      "domains": [
+        "animation",
+        "3d"
+      ]
     },
     {
       "id": "skill/running-in-the-cloud",
@@ -530,7 +771,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/running-in-the-cloud/"
+      "path": "library/skills/running-in-the-cloud/",
+      "domains": [
+        "agent-workflow",
+        "project"
+      ]
     },
     {
       "id": "skill/scene-composition",
@@ -539,7 +784,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/scene-composition/"
+      "path": "library/skills/scene-composition/",
+      "domains": [
+        "scenes",
+        "project"
+      ]
     },
     {
       "id": "skill/scene-hierarchy-design",
@@ -548,7 +797,12 @@
       "clients": "all",
       "recommended": false,
       "status": "preview",
-      "path": "library/skills/scene-hierarchy-design/"
+      "path": "library/skills/scene-hierarchy-design/",
+      "domains": [
+        "scenes",
+        "project",
+        "agent-workflow"
+      ]
     },
     {
       "id": "skill/scene-scripting",
@@ -557,7 +811,14 @@
       "clients": "all",
       "recommended": true,
       "status": "preview",
-      "path": "library/skills/scene-scripting/"
+      "path": "library/skills/scene-scripting/",
+      "domains": [
+        "scenes",
+        "scripting",
+        "2d",
+        "ui",
+        "agent-workflow"
+      ]
     },
     {
       "id": "skill/scene-to-level",
@@ -566,7 +827,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/scene-to-level/"
+      "path": "library/skills/scene-to-level/",
+      "domains": [
+        "level-design",
+        "game-design"
+      ]
     },
     {
       "id": "skill/setup-multiplayer",
@@ -575,7 +840,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/setup-multiplayer/"
+      "path": "library/skills/setup-multiplayer/",
+      "domains": [
+        "multiplayer",
+        "scripting"
+      ]
     },
     {
       "id": "skill/skill-create",
@@ -584,7 +853,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/skill-create/"
+      "path": "library/skills/skill-create/",
+      "domains": [
+        "agent-workflow",
+        "meta"
+      ]
     },
     {
       "id": "skill/skill-improve",
@@ -593,7 +866,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/skill-improve/"
+      "path": "library/skills/skill-improve/",
+      "domains": [
+        "agent-workflow",
+        "meta"
+      ]
     },
     {
       "id": "skill/skill-test",
@@ -602,7 +879,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/skill-test/"
+      "path": "library/skills/skill-test/",
+      "domains": [
+        "agent-workflow",
+        "meta"
+      ]
     },
     {
       "id": "skill/skintokens-auto-rigging",
@@ -611,7 +892,13 @@
       "clients": "all",
       "recommended": false,
       "status": "preview",
-      "path": "library/skills/skintokens-auto-rigging/"
+      "path": "library/skills/skintokens-auto-rigging/",
+      "domains": [
+        "assets",
+        "pipeline",
+        "3d",
+        "animation"
+      ]
     },
     {
       "id": "skill/skybox-panorama",
@@ -620,7 +907,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/skybox-panorama/"
+      "path": "library/skills/skybox-panorama/",
+      "domains": [
+        "2d",
+        "assets"
+      ]
     },
     {
       "id": "skill/sound-effect",
@@ -629,7 +920,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/sound-effect/"
+      "path": "library/skills/sound-effect/",
+      "domains": [
+        "audio",
+        "assets"
+      ]
     },
     {
       "id": "skill/spatial-placement",
@@ -638,7 +933,14 @@
       "clients": "all",
       "recommended": true,
       "status": "preview",
-      "path": "library/skills/spatial-placement/"
+      "path": "library/skills/spatial-placement/",
+      "domains": [
+        "scenes",
+        "3d",
+        "world-building",
+        "level-design",
+        "verification"
+      ]
     },
     {
       "id": "skill/sprite-sheet",
@@ -647,7 +949,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/sprite-sheet/"
+      "path": "library/skills/sprite-sheet/",
+      "domains": [
+        "2d",
+        "assets"
+      ]
     },
     {
       "id": "skill/tileable-texture",
@@ -656,7 +962,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/tileable-texture/"
+      "path": "library/skills/tileable-texture/",
+      "domains": [
+        "2d",
+        "assets"
+      ]
     },
     {
       "id": "skill/trailer-shot",
@@ -665,7 +975,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/trailer-shot/"
+      "path": "library/skills/trailer-shot/",
+      "domains": [
+        "video",
+        "assets"
+      ]
     },
     {
       "id": "skill/tune-performance",
@@ -674,7 +988,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/tune-performance/"
+      "path": "library/skills/tune-performance/",
+      "domains": [
+        "performance",
+        "debug"
+      ]
     },
     {
       "id": "skill/ui-basics",
@@ -683,7 +1001,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/ui-basics/"
+      "path": "library/skills/ui-basics/",
+      "domains": [
+        "ui",
+        "ux"
+      ]
     },
     {
       "id": "skill/ui-graphics",
@@ -692,7 +1014,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/ui-graphics/"
+      "path": "library/skills/ui-graphics/",
+      "domains": [
+        "2d",
+        "assets"
+      ]
     },
     {
       "id": "skill/use-widget-asset",
@@ -701,7 +1027,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/use-widget-asset/"
+      "path": "library/skills/use-widget-asset/",
+      "domains": [
+        "2d",
+        "assets"
+      ]
     },
     {
       "id": "skill/using-summer",
@@ -710,7 +1040,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/using-summer/"
+      "path": "library/skills/using-summer/",
+      "domains": [
+        "agent-workflow",
+        "meta"
+      ]
     },
     {
       "id": "skill/vehicle-model",
@@ -719,7 +1053,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/vehicle-model/"
+      "path": "library/skills/vehicle-model/",
+      "domains": [
+        "3d",
+        "assets"
+      ]
     },
     {
       "id": "skill/verification-before-completion",
@@ -728,7 +1066,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/verification-before-completion/"
+      "path": "library/skills/verification-before-completion/",
+      "domains": [
+        "agent-workflow",
+        "verification"
+      ]
     },
     {
       "id": "skill/verifying-scenes",
@@ -737,7 +1079,12 @@
       "clients": "all",
       "recommended": true,
       "status": "preview",
-      "path": "library/skills/verifying-scenes/"
+      "path": "library/skills/verifying-scenes/",
+      "domains": [
+        "scenes",
+        "verification",
+        "agent-workflow"
+      ]
     },
     {
       "id": "skill/vfx-dissolve",
@@ -746,7 +1093,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/vfx-dissolve/"
+      "path": "library/skills/vfx-dissolve/",
+      "domains": [
+        "vfx",
+        "rendering"
+      ]
     },
     {
       "id": "skill/vfx-fire",
@@ -755,7 +1106,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/vfx-fire/"
+      "path": "library/skills/vfx-fire/",
+      "domains": [
+        "vfx",
+        "rendering"
+      ]
     },
     {
       "id": "skill/vfx-hit-spark",
@@ -764,7 +1119,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/vfx-hit-spark/"
+      "path": "library/skills/vfx-hit-spark/",
+      "domains": [
+        "vfx",
+        "rendering"
+      ]
     },
     {
       "id": "skill/vfx-lightning",
@@ -773,7 +1132,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/vfx-lightning/"
+      "path": "library/skills/vfx-lightning/",
+      "domains": [
+        "vfx",
+        "rendering"
+      ]
     },
     {
       "id": "skill/vfx-magic-glow",
@@ -782,7 +1145,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/vfx-magic-glow/"
+      "path": "library/skills/vfx-magic-glow/",
+      "domains": [
+        "vfx",
+        "rendering"
+      ]
     },
     {
       "id": "skill/vfx-muzzle-flash",
@@ -791,7 +1158,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/vfx-muzzle-flash/"
+      "path": "library/skills/vfx-muzzle-flash/",
+      "domains": [
+        "vfx",
+        "rendering"
+      ]
     },
     {
       "id": "skill/vfx-smoke",
@@ -800,7 +1171,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/vfx-smoke/"
+      "path": "library/skills/vfx-smoke/",
+      "domains": [
+        "vfx",
+        "rendering"
+      ]
     },
     {
       "id": "skill/vfx-water-ripple",
@@ -809,7 +1184,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/vfx-water-ripple/"
+      "path": "library/skills/vfx-water-ripple/",
+      "domains": [
+        "vfx",
+        "rendering"
+      ]
     },
     {
       "id": "skill/voice-line",
@@ -818,7 +1197,11 @@
       "clients": "all",
       "recommended": true,
       "status": "stable",
-      "path": "library/skills/voice-line/"
+      "path": "library/skills/voice-line/",
+      "domains": [
+        "audio",
+        "assets"
+      ]
     },
     {
       "id": "skill/world-building-3d",
@@ -827,7 +1210,14 @@
       "clients": "all",
       "recommended": true,
       "status": "preview",
-      "path": "library/skills/world-building-3d/"
+      "path": "library/skills/world-building-3d/",
+      "domains": [
+        "scenes",
+        "3d",
+        "world-building",
+        "level-design",
+        "verification"
+      ]
     },
     {
       "id": "skill/writing-plans",
@@ -836,7 +1226,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/writing-plans/"
+      "path": "library/skills/writing-plans/",
+      "domains": [
+        "agent-workflow",
+        "meta"
+      ]
     },
     {
       "id": "skill/writing-skills",
@@ -845,7 +1239,11 @@
       "clients": "all",
       "recommended": false,
       "status": "stable",
-      "path": "library/skills/writing-skills/"
+      "path": "library/skills/writing-skills/",
+      "domains": [
+        "agent-workflow",
+        "meta"
+      ]
     }
   ]
 }

--- a/scripts/generate-registry/generate-registry.test.ts
+++ b/scripts/generate-registry/generate-registry.test.ts
@@ -60,6 +60,7 @@ describe("generateRegistry: catalog outputs", () => {
       "plugin.codex.json",
       "plugin.cursor.json",
       "plugin.factory.json",
+      "skills-index.md",
       "skills-registry.json",
       "templates-registry.json",
     ]);
@@ -178,6 +179,19 @@ describe("generateRegistry: catalog outputs", () => {
     });
   });
 
+  it("skills-index.md groups skills by primary domain with summary and secondary domains", () => {
+    const result = gen(basicRoot);
+    const md = result.files.get("skills-index.md")!;
+    expect(md.startsWith("# Summer skills\n")).toBe(true);
+    expect(md).toContain("> 2 skills, grouped by their primary domain.");
+    expect(md).toContain("## meta");
+    expect(md).toMatch(/\| \[alpha-skill\]\(\.\/alpha-skill\/SKILL\.md\) ★ \| .+ \| verification \|/);
+    // beta is preview: italicised, marked, no star.
+    expect(md).toContain("## meta");
+    expect(md).toMatch(/\| \[\*beta-skill\*\]\(\.\/beta-skill\/SKILL\.md\) \(preview\) \| .+ \| verification \|/);
+    expect(md.endsWith("\n")).toBe(true);
+  });
+
   it("skills-registry.json uses SKILL.md frontmatter with slug/summary fallbacks", () => {
     const result = gen(basicRoot);
     const reg = parse(result.files, "skills-registry.json");
@@ -190,6 +204,7 @@ describe("generateRegistry: catalog outputs", () => {
         recommended: true,
         status: "stable",
         path: "library/skills/alpha-skill/",
+        domains: ["meta", "verification"],
       },
       {
         id: "skill/beta-skill",
@@ -199,6 +214,7 @@ describe("generateRegistry: catalog outputs", () => {
         recommended: false,
         status: "preview",
         path: "library/skills/beta-skill/",
+        domains: ["meta", "verification"],
       },
     ]);
   });

--- a/scripts/generate-registry/index.ts
+++ b/scripts/generate-registry/index.ts
@@ -273,9 +273,71 @@ function buildSkillsRegistry(resources: LoadedResource[]): string {
         // (preview is a label; --stable-only skips it), never `deprecated`.
         status: String(res.data.status ?? "stable"),
         path: `library/skills/${res.slug}/`,
+        // First domain is the primary one (authors list it first); the CLI's
+        // `skills list --by-domain` and the generated index group by it.
+        domains: skillDomains(res),
       };
     });
   return stableJson({ _generated: GENERATED_BANNER, skills });
+}
+
+function skillDomains(res: LoadedResource): string[] {
+  const facets = asRecord(res.data.facets);
+  return Array.isArray(facets.domains) ? facets.domains.map(String) : [];
+}
+
+/**
+ * library/skills/README.md — the human view of the flat skills folder
+ * (DECISIONS.md D3: folders are flat, categories are facets). One section per
+ * primary domain, one line per skill: slug, status, the resource summary.
+ * Rendered here so `--check` fails when the index and the library disagree.
+ */
+export function buildSkillsIndexMarkdown(resources: LoadedResource[]): string {
+  const skills = resources.filter((r) => r.kind === "skill");
+  const byDomain = new Map<string, LoadedResource[]>();
+  for (const res of skills) {
+    const primary = skillDomains(res)[0] ?? "uncategorised";
+    const list = byDomain.get(primary) ?? [];
+    list.push(res);
+    byDomain.set(primary, list);
+  }
+  const domains = [...byDomain.keys()].sort();
+  const lines: string[] = [];
+  lines.push("# Summer skills");
+  lines.push("");
+  lines.push(
+    `> ${skills.length} skills, grouped by their primary domain. **Generated** by \`npm run generate:registry\` from each skill's \`resource.yaml\`; \`--check\` fails when this file and the library disagree. Do not edit by hand.`
+  );
+  lines.push("");
+  lines.push(
+    "The folder is flat on purpose (`docs/design/DECISIONS.md`, D3): a skill usually belongs to several domains, so categories live in each skill's `facets.domains` and this index is rendered from them. The first domain listed is the primary one. `summer skills list --by-domain` prints the same grouping; `summer skills info <slug>` shows one skill."
+  );
+  lines.push("");
+  lines.push("Status: **stable** unless marked; *preview* = not yet exercised in-engine by the Summer team; ~~deprecated~~ installs only by name. ★ = installed by `--recommended`.");
+  lines.push("");
+  lines.push("## Domains");
+  lines.push("");
+  for (const domain of domains) {
+    lines.push(`- [${domain}](#${domain}) (${byDomain.get(domain)!.length})`);
+  }
+  lines.push("");
+  for (const domain of domains) {
+    lines.push(`## ${domain}`);
+    lines.push("");
+    lines.push("| skill | when to use | also |");
+    lines.push("|---|---|---|");
+    for (const res of byDomain.get(domain)!.sort((a, b) => (a.slug < b.slug ? -1 : 1))) {
+      const status = String(res.data.status ?? "stable");
+      const name =
+        status === "deprecated" ? `~~${res.slug}~~` : status === "preview" ? `*${res.slug}*` : res.slug;
+      const star = res.data.recommended === true ? " ★" : "";
+      const summary = String(res.data.summary ?? "").replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
+      const also = skillDomains(res).slice(1).join(", ") || "—";
+      lines.push(`| [${name}](./${res.slug}/SKILL.md)${star}${status === "preview" ? " (preview)" : ""} | ${summary} | ${also} |`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
 }
 
 function buildTemplatesRegistry(resources: LoadedResource[]): string {
@@ -356,6 +418,7 @@ export function generateRegistry(rootDir: string, options?: GenerateOptions): Ge
   files.set("aliases.json", aliasesJson);
   files.set("skills-registry.json", buildSkillsRegistry(resources));
   files.set("templates-registry.json", buildTemplatesRegistry(resources));
+  files.set("skills-index.md", buildSkillsIndexMarkdown(resources));
 
   const skillSlugs = resources.filter((r) => r.kind === "skill").map((r) => r.slug);
   for (const [name, content] of buildManifests({

--- a/scripts/generate-registry/targets.ts
+++ b/scripts/generate-registry/targets.ts
@@ -66,6 +66,15 @@ export const MANIFEST_TARGETS: Record<string, ManifestTarget[]> = {
   warp: [],
 };
 
+/**
+ * Generated documents that are not agent manifests. Applied and drift-checked
+ * exactly like the manifests, but not mirrored in integrations/.
+ */
+export const DOC_TARGETS: ManifestTarget[] = [
+  // The human index of the flat skills folder (see buildSkillsIndexMarkdown).
+  { generated: "skills-index.md", destination: "library/skills/README.md" },
+];
+
 export function allTargets(): ManifestTarget[] {
-  return Object.values(MANIFEST_TARGETS).flat();
+  return [...Object.values(MANIFEST_TARGETS).flat(), ...DOC_TARGETS];
 }

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -311,19 +311,33 @@ export const skillsCommand = new Command("skills")
 skillsCommand
   .command("list")
   .description("List available skills")
-  .action(() => {
+  .option("--by-domain", "Group skills by their primary domain (same grouping as library/skills/README.md)")
+  .action((opts: { byDomain?: boolean }) => {
     const skills = getBuiltinSkills();
     if (skills.length === 0) {
       console.log("No skills found.");
       return;
     }
-    console.log("Available public skills:\n");
-    for (const s of skills) {
+    const line = (s: SkillMeta) => {
       const badge = s.recommended ? "recommended" : "optional";
       const tag = s.status === "preview" ? "[preview] " : "";
-      console.log(
-        `  ${s.name.padEnd(24)} ${badge.padEnd(11)} ${tag}${s.description}`
-      );
+      return `  ${s.name.padEnd(24)} ${badge.padEnd(11)} ${tag}${s.description}`;
+    };
+    if (opts.byDomain) {
+      const groups = new Map<string, SkillMeta[]>();
+      for (const s of skills) {
+        const primary = s.domains[0] ?? "uncategorised";
+        groups.set(primary, [...(groups.get(primary) ?? []), s]);
+      }
+      console.log(`${skills.length} skills by primary domain (full index: library/skills/README.md):`);
+      for (const domain of [...groups.keys()].sort()) {
+        const group = groups.get(domain)!;
+        console.log(`\n${domain} (${group.length})`);
+        for (const s of group) console.log(line(s));
+      }
+    } else {
+      console.log("Available public skills:\n");
+      for (const s of skills) console.log(line(s));
     }
     const previewCount = skills.filter((s) => s.status === "preview").length;
     if (previewCount > 0) {

--- a/src/core/skills-registry.ts
+++ b/src/core/skills-registry.ts
@@ -69,6 +69,8 @@ export interface SkillRegistryEntry {
   status: SkillStatus;
   /** Package-root-relative skill dir, e.g. "library/skills/3d-lighting/". */
   path: string;
+  /** facets.domains from resource.yaml; the first is the primary domain. Empty on old registries. */
+  domains: string[];
 }
 
 const packageRoot = PACKAGE_ROOT;
@@ -82,6 +84,7 @@ interface RawSkillEntry {
   recommended?: unknown;
   status?: unknown;
   path?: unknown;
+  domains?: unknown;
 }
 
 let cache: SkillRegistryEntry[] | null = null;
@@ -116,6 +119,7 @@ export function parseSkillRegistry(json: unknown): SkillRegistryEntry[] {
       recommended: s.recommended === true,
       status: s.status === "preview" || s.status === "deprecated" ? s.status : "stable",
       path: s.path as string,
+      domains: Array.isArray(s.domains) ? s.domains.filter((d): d is string => typeof d === "string") : [],
     }));
 }
 


### PR DESCRIPTION
## Summary

The flat `library/skills/` layout is right for agents (DECISIONS.md D3) but unreadable for people. This adds the human view without changing the layout:

- `library/skills/README.md` is **generated** by `npm run generate:registry` from each skill's `facets.domains`: one section per primary domain (first listed), one line per skill with status, ★ for recommended, the resource summary, and the secondary domains. Applied and drift-checked exactly like the agent manifests (new `DOC_TARGETS` in `targets.ts`).
- `skills-registry.json` entries carry `domains`; `summer skills list --by-domain` prints the same grouping in the terminal.
- `docs/SKILLS.md` and the README point at both.

## Test plan

- [x] `npx vitest run` (1480 tests incl. new index-shape test), `npm run generate:registry -- --check`, `npm run validate:library`, `npm run build`
- [x] `summer skills list --by-domain` output checked by hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)