### PR TITLE
fix(setup): block-style YAML for Goose and Hermes configs

### DIFF
--- a/src/installer/agent-config.ts
+++ b/src/installer/agent-config.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "fs";
 import { copyFile, mkdir, readFile, writeFile } from "fs/promises";
 import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
-import { isMap, parseDocument } from "yaml";
+import { Document, isMap, parseDocument } from "yaml";
 import { PACKAGE_ROOT } from "../core/package-root.js";
 import {
   agentAliasMap,
@@ -217,7 +217,7 @@ export function renderConfigSnippet(
     return renderJsonFile(geminiExtensionManifest(server, readBundledGeminiManifestSync()));
   }
   if (format === "yaml-goose" || format === "yaml-hermes") {
-    const doc = parseDocument("{}");
+    const doc = new Document({});
     doc.setIn([topLevelKey(format), SUMMER_MCP_SERVER_NAME], doc.createNode(mcpEntry(format, server)));
     return doc.toString();
   }
@@ -360,7 +360,9 @@ async function upsertYamlConfig(
   write: boolean
 ): Promise<{ changed: boolean }> {
   const current = await readTextFileIfExists(path);
-  const doc = parseDocument(current.trim() === "" ? "{}" : current);
+  // An empty file starts from a fresh block-style document; parseDocument("{}")
+  // would make the root a flow mapping and the whole file would render as {}.
+  const doc = current.trim() === "" ? new Document({}) : parseDocument(current);
   if (doc.errors.length > 0) {
     throw new Error(`Could not parse YAML in ${path}: ${doc.errors[0].message}`);
   }

--- a/src/installer/agent-table.test.ts
+++ b/src/installer/agent-table.test.ts
@@ -274,6 +274,17 @@ describe("config file shapes", () => {
     });
   });
 
+  it("yaml: a fresh file and the printed snippet are block-style, not a flow mapping", async () => {
+    const snippet = renderConfigSnippet("goose", { command: "npx", args: NPX_ARGS });
+    expect(snippet.startsWith("extensions:\n  summer-engine:\n")).toBe(true);
+    expect(snippet.startsWith("{")).toBe(false);
+    const dir = tmp();
+    const path = join(dir, "config.yaml");
+    await configureAgentMcp({ agent: "hermes", scope: "user", env: { SUMMER_HERMES_CONFIG_FILE: path } as NodeJS.ProcessEnv });
+    const text = readFileSync(path, "utf-8");
+    expect(text.startsWith("mcp_servers:\n  summer-engine:\n    command: npx\n")).toBe(true);
+  });
+
   it("yaml-goose: second run is a no-op", async () => {
     const dir = tmp();
     const path = join(dir, "config.yaml");


### PR DESCRIPTION
## Summary

`summer setup goose` on an empty config (and `--print` for goose/hermes) rendered the file as one flow mapping (`{ extensions: { ... } }`) because the writer started from `parseDocument("{}")`. It now starts from a fresh `Document`, so new files are block-style YAML like every hand-written Goose config. Existing files are untouched in style, as before.

## Test plan

- [x] New test: printed snippet and a fresh Hermes file start with the block-style key
- [x] `npx vitest run` 1483 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)