### PR TITLE
release: 3.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "summer",
       "source": "./",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "description": "Agent tooling for Summer Engine: game-dev skills, lifecycle hooks, and a 86-tool MCP bridge to the local desktop app.",
       "author": {
         "name": "Summer Engine",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "_generated": "GENERATED from integrations/claude — do not edit; npm run generate:registry",
   "name": "summer",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Agent tooling for Summer Engine: game-dev skills, lifecycle hooks, and a 86-tool MCP bridge to the local desktop app.",
   "author": {
     "name": "Summer Engine",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "GENERATED from integrations/codex — do not edit; npm run generate:registry",
   "name": "summer",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Agent tooling for Summer Engine: game-dev skills, lifecycle hooks, and a 86-tool MCP bridge. Build games by talking.",
   "author": {
     "name": "Summer Engine",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "_generated": "GENERATED from integrations/cursor — do not edit; npm run generate:registry",
   "name": "summer",
   "displayName": "Summer",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Agent tooling for Summer Engine: game-dev skills, lifecycle hooks, and a 86-tool MCP bridge to the local desktop app.",
   "author": {
     "name": "Summer Engine",

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -2,7 +2,7 @@
   "_generated": "GENERATED from integrations/factory — do not edit; npm run generate:registry",
   "name": "summer",
   "description": "Agent tooling for Summer Engine: game-dev skills, lifecycle hooks, and a 86-tool MCP bridge to the local desktop app.",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": {
     "name": "Summer Engine",
     "email": "founders@summerengine.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to summer-engine will be documented here. Following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [3.1.1] - 2026-09-11
+
+### Fixed
+- `summer setup goose` / `hermes` on an empty config wrote the file as one flow mapping; new files are block-style YAML.
 
 ### Changed
 - Agents whose docs read the agentskills.io folder now install skills to `~/.agents/skills` (project: `.agents/skills`) instead of each agent's own folder: Codex, Cursor, Zed, OpenCode, Copilot in VS Code, Devin Desktop, Amp, Crush, Warp, Kimi Code, Factory Droid, Rovo Dev, Grok Build; Antigravity, Goose, Hermes and Mistral Vibe at project scope. One install serves all of them and "where are the skills" has one answer. `skills install --force` removes the copies 3.1.0 wrote in the old per-agent folders.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "_generated": "GENERATED from integrations/gemini — do not edit; npm run generate:registry",
   "name": "summer",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Agent tooling for Summer Engine: MCP bridge, context primer, and game-dev skills. Use with the npm CLI for skill files on disk.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "summer-engine",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "summer-engine",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "summer-engine",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Local Summer CLI and MCP server for Summer Engine. Install and run the engine, connect Claude Code, Cursor, Codex, Gemini, and other agents, and build real games with bundled skills, hooks, and plugins.",
   "keywords": [
     "summer-engine",

--- a/registry/generated/gemini-extension.json
+++ b/registry/generated/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "_generated": "GENERATED from integrations/gemini — do not edit; npm run generate:registry",
   "name": "summer",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Agent tooling for Summer Engine: MCP bridge, context primer, and game-dev skills. Use with the npm CLI for skill files on disk.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {

--- a/registry/generated/marketplace.claude.json
+++ b/registry/generated/marketplace.claude.json
@@ -11,7 +11,7 @@
     {
       "name": "summer",
       "source": "./",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "description": "Agent tooling for Summer Engine: game-dev skills, lifecycle hooks, and a 86-tool MCP bridge to the local desktop app.",
       "author": {
         "name": "Summer Engine",

--- a/registry/generated/plugin.claude.json
+++ b/registry/generated/plugin.claude.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "_generated": "GENERATED from integrations/claude — do not edit; npm run generate:registry",
   "name": "summer",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Agent tooling for Summer Engine: game-dev skills, lifecycle hooks, and a 86-tool MCP bridge to the local desktop app.",
   "author": {
     "name": "Summer Engine",

--- a/registry/generated/plugin.codex.json
+++ b/registry/generated/plugin.codex.json
@@ -1,7 +1,7 @@
 {
   "_generated": "GENERATED from integrations/codex — do not edit; npm run generate:registry",
   "name": "summer",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Agent tooling for Summer Engine: game-dev skills, lifecycle hooks, and a 86-tool MCP bridge. Build games by talking.",
   "author": {
     "name": "Summer Engine",

--- a/registry/generated/plugin.cursor.json
+++ b/registry/generated/plugin.cursor.json
@@ -3,7 +3,7 @@
   "_generated": "GENERATED from integrations/cursor — do not edit; npm run generate:registry",
   "name": "summer",
   "displayName": "Summer",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Agent tooling for Summer Engine: game-dev skills, lifecycle hooks, and a 86-tool MCP bridge to the local desktop app.",
   "author": {
     "name": "Summer Engine",

--- a/registry/generated/plugin.factory.json
+++ b/registry/generated/plugin.factory.json
@@ -2,7 +2,7 @@
   "_generated": "GENERATED from integrations/factory — do not edit; npm run generate:registry",
   "name": "summer",
   "description": "Agent tooling for Summer Engine: game-dev skills, lifecycle hooks, and a 86-tool MCP bridge to the local desktop app.",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": {
     "name": "Summer Engine",
     "email": "founders@summerengine.com",


### PR DESCRIPTION
## Summary

Version bump for the shared `~/.agents/skills` install (#28) and the YAML block-style fix (#29). Changelog folded from Unreleased.

## Test plan

- [x] `npx vitest run`, `npm run generate:registry -- --check`, `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)